### PR TITLE
Feature/cc3200 build doc

### DIFF
--- a/doc/tutorial_ti_cc3200.md
+++ b/doc/tutorial_ti_cc3200.md
@@ -375,7 +375,7 @@ Reaching this point means you are able to produce and execute CC3200 compatible 
                 #define USER_NAME   "UsernameIfAny"
                 #define PASSWORD    "Password"
 
-        - select security type according to your wifi settings, in case of WPA2 set
+        - select security type in EntWlan() function according to your wifi settings, in case of WPA2 set
 
                 g_SecParams.Type = SL_SEC_TYPE_WPA_WPA2;
 


### PR DESCRIPTION
The doc has a better format here: https://github.com/xively/xively-client-c/blob/feature/cc3200_build_doc/src/bsp/platform/cc3200/how_to_build_and_run_on_cc3200.md

The process of building an application on a cc3200 board is still formulating thus the documentation hasn't got its final shape. Until a reasonable example build process is not reached this doc won't be merged to dev.
