### PR TITLE
Removed empty space at the end of copyright notice in source.

### DIFF
--- a/examples/common/src/commandline.c
+++ b/examples/common/src/commandline.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /*

--- a/examples/common/src/commandline.h
+++ b/examples/common/src/commandline.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /*

--- a/examples/mqtt_last_will/src/mqtt_last_will.c
+++ b/examples/mqtt_last_will/src/mqtt_last_will.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /*
@@ -10,7 +10,7 @@
  * test messages to a topic that you also must specify
  *
  * This example application is meant as a companion example to
- * mqtt_logic_consumer example. 
+ * mqtt_logic_consumer example.
  */
 
 #include <xively.h>

--- a/examples/mqtt_logic_consumer/src/mqtt_logic_consumer.c
+++ b/examples/mqtt_logic_consumer/src/mqtt_logic_consumer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /*

--- a/examples/mqtt_logic_example/src/mqtt_logic_example.c
+++ b/examples/mqtt_logic_example/src/mqtt_logic_example.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "../../common/src/commandline.h"

--- a/examples/mqtt_logic_example_two_contexts/src/mqtt_logic_example_two_contexts.c
+++ b/examples/mqtt_logic_example_two_contexts/src/mqtt_logic_example_two_contexts.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "../../common/src/commandline.h"

--- a/examples/mqtt_logic_producer/src/mqtt_logic_producer.c
+++ b/examples/mqtt_logic_producer/src/mqtt_logic_producer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /*

--- a/examples/senml_serializer/src/senml_serializer.c
+++ b/examples/senml_serializer/src/senml_serializer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /*

--- a/include/bsp/xi_bsp_io_net.h
+++ b/include/bsp/xi_bsp_io_net.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_BSP_IO_NET_H__

--- a/include/bsp/xi_bsp_mem.h
+++ b/include/bsp/xi_bsp_mem.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_BSP_MEM_H__

--- a/include/bsp/xi_bsp_rng.h
+++ b/include/bsp/xi_bsp_rng.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_BSP_RNG_H__

--- a/include/bsp/xi_bsp_time.h
+++ b/include/bsp/xi_bsp_time.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_BSP_TIME_H__

--- a/include/bsp/xi_bsp_tls.h
+++ b/include/bsp/xi_bsp_tls.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_BSP_TLS_H__

--- a/include/xively.h
+++ b/include/xively.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_H__

--- a/include/xively_connection_data.h
+++ b/include/xively_connection_data.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_CONNECTION_DATA_H__

--- a/include/xively_error.h
+++ b/include/xively_error.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_ERROR_H__

--- a/include/xively_mqtt.h
+++ b/include/xively_mqtt.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_MQTT_H__

--- a/include/xively_time.h
+++ b/include/xively_time.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_TIME_H__

--- a/include/xively_types.h
+++ b/include/xively_types.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_TYPES_H__

--- a/include_senml/xively_senml.h
+++ b/include_senml/xively_senml.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_SENML_H__

--- a/include_senml/xively_senml_macros.h
+++ b/include_senml/xively_senml_macros.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_SENML_MACROS_H__

--- a/include_senml/xively_senml_types.h
+++ b/include_senml/xively_senml_types.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_SENML_TYPES_H__

--- a/src/bsp/platform/cc3200/xi_bsp_io_net_cc3200.c
+++ b/src/bsp/platform/cc3200/xi_bsp_io_net_cc3200.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <socket.h>

--- a/src/bsp/platform/cc3200/xi_bsp_mem_cc3200.c
+++ b/src/bsp/platform/cc3200/xi_bsp_mem_cc3200.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_bsp_mem.h"

--- a/src/bsp/platform/cc3200/xi_bsp_rng_cc3200.c
+++ b/src/bsp/platform/cc3200/xi_bsp_rng_cc3200.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_rng.h>

--- a/src/bsp/platform/cc3200/xi_bsp_time_cc3200.c
+++ b/src/bsp/platform/cc3200/xi_bsp_time_cc3200.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_time.h>

--- a/src/bsp/platform/cc3200/xi_bsp_time_cc3200_sntp.c
+++ b/src/bsp/platform/cc3200/xi_bsp_time_cc3200_sntp.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /******************************************************************************

--- a/src/bsp/platform/cc3200/xi_bsp_time_cc3200_sntp.h
+++ b/src/bsp/platform/cc3200/xi_bsp_time_cc3200_sntp.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_BSP_TIME_CC3200_SNTP_H__

--- a/src/bsp/platform/dummy/xi_bsp_io_net_dummy.c
+++ b/src/bsp/platform/dummy/xi_bsp_io_net_dummy.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/bsp/platform/dummy/xi_bsp_mem_dummy.c
+++ b/src/bsp/platform/dummy/xi_bsp_mem_dummy.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_mem.h>

--- a/src/bsp/platform/dummy/xi_bsp_rng_dummy.c
+++ b/src/bsp/platform/dummy/xi_bsp_rng_dummy.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_rng.h>

--- a/src/bsp/platform/dummy/xi_bsp_time_dummy.c
+++ b/src/bsp/platform/dummy/xi_bsp_time_dummy.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_time.h>

--- a/src/bsp/platform/microchip_incomplete/xi_bsp_io_net_microchip.c
+++ b/src/bsp/platform/microchip_incomplete/xi_bsp_io_net_microchip.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_io_net.h>

--- a/src/bsp/platform/microchip_incomplete/xi_bsp_time_microchip.c
+++ b/src/bsp/platform/microchip_incomplete/xi_bsp_time_microchip.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_time.h>

--- a/src/bsp/platform/posix/xi_bsp_io_net_posix.c
+++ b/src/bsp/platform/posix/xi_bsp_io_net_posix.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_io_net.h>

--- a/src/bsp/platform/posix/xi_bsp_mem_posix.c
+++ b/src/bsp/platform/posix/xi_bsp_mem_posix.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_mem.h>

--- a/src/bsp/platform/posix/xi_bsp_rng_posix.c
+++ b/src/bsp/platform/posix/xi_bsp_rng_posix.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_rng.h>

--- a/src/bsp/platform/posix/xi_bsp_time_posix.c
+++ b/src/bsp/platform/posix/xi_bsp_time_posix.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_time.h>

--- a/src/bsp/platform/simplelink_incomplete/xi_bsp_io_net_simplelink.c
+++ b/src/bsp/platform/simplelink_incomplete/xi_bsp_io_net_simplelink.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_io_net.h>

--- a/src/bsp/platform/wmsdk_incomplete/xi_bsp_mem_wmsdk.c
+++ b/src/bsp/platform/wmsdk_incomplete/xi_bsp_mem_wmsdk.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_bsp_mem.h"

--- a/src/bsp/platform/wmsdk_incomplete/xi_bsp_time_wmsdk.c
+++ b/src/bsp/platform/wmsdk_incomplete/xi_bsp_time_wmsdk.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_time.h>

--- a/src/bsp/tls/mbedtls/xi_bsp_tls_mbedtls.c
+++ b/src/bsp/tls/mbedtls/xi_bsp_tls_mbedtls.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <assert.h>

--- a/src/bsp/tls/wolfssl/xi_bsp_tls_wolfssl.c
+++ b/src/bsp/tls/wolfssl/xi_bsp_tls_wolfssl.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <assert.h>

--- a/src/examples/internal/mqtt_logic_cont_sess_example.c
+++ b/src/examples/internal/mqtt_logic_cont_sess_example.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xively.h>

--- a/src/examples/internal/mqtt_logic_example_tls_bsp.c
+++ b/src/examples/internal/mqtt_logic_example_tls_bsp.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xively.h>

--- a/src/examples/internal/xi_coroutine.c
+++ b/src/examples/internal/xi_coroutine.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/examples/wmsdk/mqtt_logic_test/src/mqtt_logic_test.c
+++ b/src/examples/wmsdk/mqtt_logic_test/src/mqtt_logic_test.c
@@ -1,9 +1,9 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
- 
+
 #include <wm_os.h>
 #include <app_framework.h>
 #include <wmtime.h>

--- a/src/experimental/heap_allocator/src/debug.h
+++ b/src/experimental/heap_allocator/src/debug.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/experimental/heap_allocator/src/list.c
+++ b/src/experimental/heap_allocator/src/list.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "list.h"

--- a/src/experimental/heap_allocator/src/list.h
+++ b/src/experimental/heap_allocator/src/list.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __LIST_H__

--- a/src/experimental/heap_allocator/src/main.c
+++ b/src/experimental/heap_allocator/src/main.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/experimental/heap_allocator/src/stack_allocator.c
+++ b/src/experimental/heap_allocator/src/stack_allocator.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "stack_allocator.h"

--- a/src/experimental/heap_allocator/src/stack_allocator.h
+++ b/src/experimental/heap_allocator/src/stack_allocator.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XIVELY_EXPERIMENTAL_STACK_ALLOCATOR_H__

--- a/src/experimental/heap_allocator/src/stack_allocator_debug.c
+++ b/src/experimental/heap_allocator/src/stack_allocator_debug.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "stack_allocator_debug.h"

--- a/src/experimental/heap_allocator/src/stack_allocator_debug.h
+++ b/src/experimental/heap_allocator/src/stack_allocator_debug.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __STACK_ALLOCATOR_DEBUG_H__

--- a/src/libxively/control_topic/xi_control_topic_layer.c
+++ b/src/libxively/control_topic/xi_control_topic_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_control_topic_layer.h"

--- a/src/libxively/control_topic/xi_control_topic_layer.h
+++ b/src/libxively/control_topic/xi_control_topic_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_CONTROL_TOPIC_LAYER_LAYER_H__

--- a/src/libxively/control_topic/xi_control_topic_layer_data.h
+++ b/src/libxively/control_topic/xi_control_topic_layer_data.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_CONTROL_TOPIC_LAYER_LAYER_DATA_H__

--- a/src/libxively/datastructures/xi_heap.c
+++ b/src/libxively/datastructures/xi_heap.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_heap.h"

--- a/src/libxively/datastructures/xi_heap.h
+++ b/src/libxively/datastructures/xi_heap.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_HEAP_H__

--- a/src/libxively/datastructures/xi_list.h
+++ b/src/libxively/datastructures/xi_list.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LIST_H__

--- a/src/libxively/datastructures/xi_memory_type.h
+++ b/src/libxively/datastructures/xi_memory_type.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MEMORY_TYPE_H__

--- a/src/libxively/datastructures/xi_vector.c
+++ b/src/libxively/datastructures/xi_vector.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_vector.h"

--- a/src/libxively/datastructures/xi_vector.h
+++ b/src/libxively/datastructures/xi_vector.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_VECTOR_H__

--- a/src/libxively/debug_extensions/memory_limiter/xi_memory_limiter.c
+++ b/src/libxively/debug_extensions/memory_limiter/xi_memory_limiter.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdint.h>

--- a/src/libxively/debug_extensions/memory_limiter/xi_memory_limiter.h
+++ b/src/libxively/debug_extensions/memory_limiter/xi_memory_limiter.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MEMORY_LIMITER_H__

--- a/src/libxively/event_dispatcher/xi_event_dispatcher.c
+++ b/src/libxively/event_dispatcher/xi_event_dispatcher.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <inttypes.h>

--- a/src/libxively/event_dispatcher/xi_event_dispatcher_api.h
+++ b/src/libxively/event_dispatcher/xi_event_dispatcher_api.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_EVENT_DISPATCHER_API_H__

--- a/src/libxively/event_dispatcher/xi_event_dispatcher_macros.h
+++ b/src/libxively/event_dispatcher/xi_event_dispatcher_macros.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_EVENT_DISPATCHER_MACROS_H__

--- a/src/libxively/event_dispatcher/xi_event_handle.c
+++ b/src/libxively/event_dispatcher/xi_event_handle.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_config.h"

--- a/src/libxively/event_dispatcher/xi_event_handle.h
+++ b/src/libxively/event_dispatcher/xi_event_handle.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_EVENT_HANDLE_H__

--- a/src/libxively/event_dispatcher/xi_event_handle_queue.h
+++ b/src/libxively/event_dispatcher/xi_event_handle_queue.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_EVENT_HANDLE_QUEUE_H__

--- a/src/libxively/event_dispatcher/xi_event_handle_typedef.h
+++ b/src/libxively/event_dispatcher/xi_event_handle_typedef.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_HANDLE_TYPEDEF_H__

--- a/src/libxively/event_dispatcher/xi_event_thread_dispatcher.c
+++ b/src/libxively/event_dispatcher/xi_event_thread_dispatcher.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifdef XI_MODULE_THREAD_ENABLED

--- a/src/libxively/event_dispatcher/xi_event_thread_dispatcher.h
+++ b/src/libxively/event_dispatcher/xi_event_thread_dispatcher.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_EVENT_THREAD_DISPATCHER_H__

--- a/src/libxively/event_loop/xi_event_loop.c
+++ b/src/libxively/event_loop/xi_event_loop.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_bsp_io_net.h"

--- a/src/libxively/event_loop/xi_event_loop.h
+++ b/src/libxively/event_loop/xi_event_loop.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_EVENT_LOOP_H__

--- a/src/libxively/io/fs/dummy/xi_fs_dummy.c
+++ b/src/libxively/io/fs/dummy/xi_fs_dummy.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_fs_header.h"

--- a/src/libxively/io/fs/memory/xi_fs_memory.c
+++ b/src/libxively/io/fs/memory/xi_fs_memory.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_fs_header.h"

--- a/src/libxively/io/fs/posix/xi_fs_posix.c
+++ b/src/libxively/io/fs/posix/xi_fs_posix.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_fs_header.h"

--- a/src/libxively/io/fs/xi_fs_api.h
+++ b/src/libxively/io/fs/xi_fs_api.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_FS_API_H__

--- a/src/libxively/io/fs/xi_fs_filename_defs.h
+++ b/src/libxively/io/fs/xi_fs_filename_defs.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_FS_FILENAME_DEFS_H__

--- a/src/libxively/io/fs/xi_fs_filenames.c
+++ b/src/libxively/io/fs/xi_fs_filenames.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_fs_filename_defs.h"

--- a/src/libxively/io/fs/xi_fs_filenames.h
+++ b/src/libxively/io/fs/xi_fs_filenames.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_FS_FILENAMES_H__

--- a/src/libxively/io/fs/xi_fs_header.h
+++ b/src/libxively/io/fs/xi_fs_header.h
@@ -1,9 +1,9 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
- 
+
 #ifndef __XI_FS_HEADER_H__
 #define __XI_FS_HEADER_H__
 

--- a/src/libxively/io/fs/xi_resource_manager.c
+++ b/src/libxively/io/fs/xi_resource_manager.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_resource_manager.h"

--- a/src/libxively/io/fs/xi_resource_manager.h
+++ b/src/libxively/io/fs/xi_resource_manager.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_RESOURCE_MANAGER_H__

--- a/src/libxively/io/net/xi_io_net_layer.c
+++ b/src/libxively/io/net/xi_io_net_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_io_net_layer.h"

--- a/src/libxively/io/net/xi_io_net_layer.h
+++ b/src/libxively/io/net/xi_io_net_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_IO_NET_LAYER_H__

--- a/src/libxively/io/net/xi_io_net_layer_state.h
+++ b/src/libxively/io/net/xi_io_net_layer_state.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_IO_NET_LAYER_STATE_H__

--- a/src/libxively/memory/xi_allocator.c
+++ b/src/libxively/memory/xi_allocator.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_allocator.h"

--- a/src/libxively/memory/xi_allocator.h
+++ b/src/libxively/memory/xi_allocator.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_PLATFORM_ALLOCATOR_H__

--- a/src/libxively/mqtt/codec/xi_mqtt_codec_layer.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_codec_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_coroutine.h"

--- a/src/libxively/mqtt/codec/xi_mqtt_codec_layer.h
+++ b/src/libxively/mqtt/codec/xi_mqtt_codec_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_CODEC_LAYER_H__

--- a/src/libxively/mqtt/codec/xi_mqtt_codec_layer_data.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_codec_layer_data.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_mqtt_codec_layer_data.h"

--- a/src/libxively/mqtt/codec/xi_mqtt_codec_layer_data.h
+++ b/src/libxively/mqtt/codec/xi_mqtt_codec_layer_data.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_CODEC_LAYER_DATA_H__

--- a/src/libxively/mqtt/codec/xi_mqtt_errors.h
+++ b/src/libxively/mqtt/codec/xi_mqtt_errors.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_ERRORS_H__

--- a/src/libxively/mqtt/codec/xi_mqtt_message.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_message.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <string.h>

--- a/src/libxively/mqtt/codec/xi_mqtt_message.h
+++ b/src/libxively/mqtt/codec/xi_mqtt_message.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_MESSAGE_H__

--- a/src/libxively/mqtt/codec/xi_mqtt_parser.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_parser.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdint.h>

--- a/src/libxively/mqtt/codec/xi_mqtt_parser.h
+++ b/src/libxively/mqtt/codec/xi_mqtt_parser.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_PARSER_H__

--- a/src/libxively/mqtt/codec/xi_mqtt_serialiser.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_serialiser.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <string.h>

--- a/src/libxively/mqtt/codec/xi_mqtt_serialiser.h
+++ b/src/libxively/mqtt/codec/xi_mqtt_serialiser.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_SERIALISER_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer.c
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_backoff_status_api.h"

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_commands.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_commands.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_COMMANDS_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_connect_command.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_connect_command.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_CONNECT_COMMAND_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_connection_helpers.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_connection_helpers.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_CONNECTION_HELPERS_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_data.c
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_data.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_helpers.h"

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_data.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_data.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_DATA_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_data_helpers.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_data_helpers.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_DATA_HELPERS_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_handlers.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_handlers.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_HANDLERS_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_helpers.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_helpers.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_TASK_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_keepalive_handler.c
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_keepalive_handler.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_coroutine.h"

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_keepalive_handler.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_keepalive_handler.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_KEEPALIVE_HANDLER_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_publish_handler.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_publish_handler.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_PUBLISH_HANDLER_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_publish_q0_command.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_publish_q0_command.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_PUBLISH_Q0_COMMAND_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_publish_q1_command.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_publish_q1_command.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_PUBLISH_Q1_COMMAND_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_subscribe_command.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_subscribe_command.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_SUBSCRIBE_COMMAND_H__

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_task_helpers.c
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_task_helpers.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_list.h"

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_task_helpers.h
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_task_helpers.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MQTT_LOGIC_LAYER_TASK_HELPERS_H__

--- a/src/libxively/platform/dummy/xi_thread/xi_critical_section_def.h
+++ b/src/libxively/platform/dummy/xi_thread/xi_critical_section_def.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_CRITICAL_SECTION_DEF_H__

--- a/src/libxively/platform/posix/xi_thread/xi_critical_section_def.h
+++ b/src/libxively/platform/posix/xi_thread/xi_critical_section_def.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_POSIX_CRITICAL_SECTION_H__

--- a/src/libxively/platform/posix/xi_thread/xi_posix_critical_section.c
+++ b/src/libxively/platform/posix/xi_thread/xi_posix_critical_section.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_err.h"

--- a/src/libxively/platform/posix/xi_thread/xi_thread_posix_threadpool.c
+++ b/src/libxively/platform/posix/xi_thread/xi_thread_posix_threadpool.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_thread_threadpool.h"

--- a/src/libxively/platform/posix/xi_thread/xi_thread_posix_workerthread.c
+++ b/src/libxively/platform/posix/xi_thread/xi_thread_posix_workerthread.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <unistd.h>

--- a/src/libxively/platform/posix/xi_thread/xi_thread_posix_workerthread.h
+++ b/src/libxively/platform/posix/xi_thread/xi_thread_posix_workerthread.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_THREAD_POSIX_WORKERTHREAD_H__

--- a/src/libxively/platform/wmsdk/xi_thread/xi_critical_section_def.h
+++ b/src/libxively/platform/wmsdk/xi_thread/xi_critical_section_def.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_CRITICAL_SECTION_DEF_H__

--- a/src/libxively/platform/xi_thread/xi_critical_section.h
+++ b/src/libxively/platform/xi_thread/xi_critical_section.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_CRITICAL_SECTION_H__

--- a/src/libxively/platform/xi_thread/xi_thread_ids.h
+++ b/src/libxively/platform/xi_thread/xi_thread_ids.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_THREAD_IDS_H__

--- a/src/libxively/platform/xi_thread/xi_thread_threadpool.h
+++ b/src/libxively/platform/xi_thread/xi_thread_threadpool.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_THREAD_THREADPOOL_H__

--- a/src/libxively/platform/xi_thread/xi_thread_workerthread.h
+++ b/src/libxively/platform/xi_thread/xi_thread_workerthread.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_THREAD_WORKERTHREAD_H__

--- a/src/libxively/senml/xi_senml.c
+++ b/src/libxively/senml/xi_senml.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/libxively/senml/xi_senml_json_serializer.c
+++ b/src/libxively/senml/xi_senml_json_serializer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_debug.h"

--- a/src/libxively/senml/xi_senml_json_serializer.h
+++ b/src/libxively/senml/xi_senml_json_serializer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_SENML_JSON_SERIALIZER_H__

--- a/src/libxively/time/all/xi_time.c
+++ b/src/libxively/time/all/xi_time.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_time.h"

--- a/src/libxively/time/xi_time.c
+++ b/src/libxively/time/xi_time.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <xi_bsp_time.h>

--- a/src/libxively/time/xi_time.h
+++ b/src/libxively/time/xi_time.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_TIME_H__

--- a/src/libxively/tls/certs/xi_RootCA_list.c
+++ b/src/libxively/tls/certs/xi_RootCA_list.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifdef __cplusplus

--- a/src/libxively/tls/certs/xi_RootCA_list.h
+++ b/src/libxively/tls/certs/xi_RootCA_list.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ROOTCA_LIST_H__

--- a/src/libxively/tls/wolfssl/xi_tls_layer.c
+++ b/src/libxively/tls/wolfssl/xi_tls_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_macros.h"

--- a/src/libxively/tls/wolfssl/xi_tls_layer.h
+++ b/src/libxively/tls/wolfssl/xi_tls_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_TLS_LAYER_H__

--- a/src/libxively/tls/wolfssl/xi_tls_layer_state.h
+++ b/src/libxively/tls/wolfssl/xi_tls_layer_state.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_TLS_LAYER_STATE_H__

--- a/src/libxively/tls/xi_tls_layer.c
+++ b/src/libxively/tls/xi_tls_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_fs_filenames.h"

--- a/src/libxively/tls/xi_tls_layer.h
+++ b/src/libxively/tls/xi_tls_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_TLS_LAYER_H__

--- a/src/libxively/tls/xi_tls_layer_state.h
+++ b/src/libxively/tls/xi_tls_layer_state.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_TLS_LAYER_STATE_H__

--- a/src/libxively/xi_backoff_lut_config.h
+++ b/src/libxively/xi_backoff_lut_config.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_BACKOFF_LUT_CONFIG_H__

--- a/src/libxively/xi_backoff_status.h
+++ b/src/libxively/xi_backoff_status.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef XI_BACKOFF_STATUS_H

--- a/src/libxively/xi_backoff_status_api.c
+++ b/src/libxively/xi_backoff_status_api.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_backoff_status_api.h"

--- a/src/libxively/xi_backoff_status_api.h
+++ b/src/libxively/xi_backoff_status_api.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef XI_BACKOFF_STATUS_API_H

--- a/src/libxively/xi_common.h
+++ b/src/libxively/xi_common.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_COMMON_H__

--- a/src/libxively/xi_config.h
+++ b/src/libxively/xi_config.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_CONFIG_H__

--- a/src/libxively/xi_config_mbed.h
+++ b/src/libxively/xi_config_mbed.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_CONFIG_MBED_H__

--- a/src/libxively/xi_connection_data.c
+++ b/src/libxively/xi_connection_data.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_config.h"

--- a/src/libxively/xi_connection_data.h
+++ b/src/libxively/xi_connection_data.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_CONNECTION_DATA_H__

--- a/src/libxively/xi_control_topic_name.c
+++ b/src/libxively/xi_control_topic_name.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_control_topic_name.h"

--- a/src/libxively/xi_control_topic_name.h
+++ b/src/libxively/xi_control_topic_name.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_CONTROL_TOPIC_NAME_H__

--- a/src/libxively/xi_coroutine.h
+++ b/src/libxively/xi_coroutine.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_COROUTINE_H__

--- a/src/libxively/xi_data_desc.c
+++ b/src/libxively/xi_data_desc.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_data_desc.h"

--- a/src/libxively/xi_data_desc.h
+++ b/src/libxively/xi_data_desc.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_DATA_DESC_H__

--- a/src/libxively/xi_debug.c
+++ b/src/libxively/xi_debug.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <string.h>

--- a/src/libxively/xi_debug.h
+++ b/src/libxively/xi_debug.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /**

--- a/src/libxively/xi_err.c
+++ b/src/libxively/xi_err.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_err.h"

--- a/src/libxively/xi_err.h
+++ b/src/libxively/xi_err.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /* - Every function should return a value

--- a/src/libxively/xi_globals.c
+++ b/src/libxively/xi_globals.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_globals.h"

--- a/src/libxively/xi_globals.h
+++ b/src/libxively/xi_globals.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_GLOBALS_H__

--- a/src/libxively/xi_handle.c
+++ b/src/libxively/xi_handle.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_handle.h"

--- a/src/libxively/xi_handle.h
+++ b/src/libxively/xi_handle.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_HANDLE_H__

--- a/src/libxively/xi_helpers.c
+++ b/src/libxively/xi_helpers.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <string.h>

--- a/src/libxively/xi_helpers.h
+++ b/src/libxively/xi_helpers.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_HELPERS_H__

--- a/src/libxively/xi_internals.c
+++ b/src/libxively/xi_internals.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_internals.h"

--- a/src/libxively/xi_internals.h
+++ b/src/libxively/xi_internals.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_INTERNALS_H__

--- a/src/libxively/xi_io_timeouts.c
+++ b/src/libxively/xi_io_timeouts.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <inttypes.h>

--- a/src/libxively/xi_io_timeouts.h
+++ b/src/libxively/xi_io_timeouts.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_IO_TIMEOUTS_H__

--- a/src/libxively/xi_layer.h
+++ b/src/libxively/xi_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_H__

--- a/src/libxively/xi_layer_api.c
+++ b/src/libxively/xi_layer_api.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_config.h"

--- a/src/libxively/xi_layer_api.h
+++ b/src/libxively/xi_layer_api.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_API_H__

--- a/src/libxively/xi_layer_chain.h
+++ b/src/libxively/xi_layer_chain.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_CHAIN_H__

--- a/src/libxively/xi_layer_connectivity.h
+++ b/src/libxively/xi_layer_connectivity.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_CONNECTIVITY_H__

--- a/src/libxively/xi_layer_debug_info.h
+++ b/src/libxively/xi_layer_debug_info.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_DEBUG_INFO_H__

--- a/src/libxively/xi_layer_default_allocators.c
+++ b/src/libxively/xi_layer_default_allocators.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_layer.h"

--- a/src/libxively/xi_layer_default_allocators.h
+++ b/src/libxively/xi_layer_default_allocators.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_DEFAULT_ALLOCATORS_H__

--- a/src/libxively/xi_layer_default_functions.c
+++ b/src/libxively/xi_layer_default_functions.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_layer_default_functions.h"

--- a/src/libxively/xi_layer_default_functions.h
+++ b/src/libxively/xi_layer_default_functions.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_DEFAULT_FUNCTIONS_H__

--- a/src/libxively/xi_layer_factory.h
+++ b/src/libxively/xi_layer_factory.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_FACTORY_H__

--- a/src/libxively/xi_layer_factory_interface.h
+++ b/src/libxively/xi_layer_factory_interface.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_FACTORY_INTERFACE_H__

--- a/src/libxively/xi_layer_interface.h
+++ b/src/libxively/xi_layer_interface.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_INTERFACE_H__

--- a/src/libxively/xi_layer_macros.h
+++ b/src/libxively/xi_layer_macros.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 #ifndef __XI_FACTORY_CONF_H__
 #define __XI_FACTORY_CONF_H__

--- a/src/libxively/xi_layer_stack.h
+++ b/src/libxively/xi_layer_stack.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_STACK_H__

--- a/src/libxively/xi_layer_state.h
+++ b/src/libxively/xi_layer_state.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_STATE_H__

--- a/src/libxively/xi_layer_type.h
+++ b/src/libxively/xi_layer_type.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYER_TYPE_H__

--- a/src/libxively/xi_layers_ids.h
+++ b/src/libxively/xi_layers_ids.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAYERS_IDS_H__

--- a/src/libxively/xi_macros.h
+++ b/src/libxively/xi_macros.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MACROS_H__

--- a/src/libxively/xi_mqtt_host_accessor.h
+++ b/src/libxively/xi_mqtt_host_accessor.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /* #ifndef __XI_MQTT_HOST_ACCESSOR_H__ */

--- a/src/libxively/xi_rng.c
+++ b/src/libxively/xi_rng.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_rng.h"

--- a/src/libxively/xi_rng.h
+++ b/src/libxively/xi_rng.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_RNG_H__

--- a/src/libxively/xi_timed_task.c
+++ b/src/libxively/xi_timed_task.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_timed_task.h"

--- a/src/libxively/xi_timed_task.h
+++ b/src/libxively/xi_timed_task.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_TIMED_TASK_H__

--- a/src/libxively/xi_tuple.h
+++ b/src/libxively/xi_tuple.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_TUPLE_H__

--- a/src/libxively/xi_tuples.c
+++ b/src/libxively/xi_tuples.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef XI_TUPLES_C

--- a/src/libxively/xi_tuples.h
+++ b/src/libxively/xi_tuples.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_TUPLES_H__

--- a/src/libxively/xi_types.h
+++ b/src/libxively/xi_types.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_TYPES_H__

--- a/src/libxively/xi_user_sub_call_wrapper.c
+++ b/src/libxively/xi_user_sub_call_wrapper.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_user_sub_call_wrapper.h"

--- a/src/libxively/xi_user_sub_call_wrapper.h
+++ b/src/libxively/xi_user_sub_call_wrapper.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_USER_SUB_CALL_WRAPPER_H__

--- a/src/libxively/xi_version.h
+++ b/src/libxively/xi_version.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_VERSION_H__

--- a/src/libxively/xively.c
+++ b/src/libxively/xively.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <string.h>

--- a/src/models/xi_select_bsp_model.c
+++ b/src/models/xi_select_bsp_model.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /**

--- a/src/tests/itests/tools/dummy/xi_io_dummy_layer.c
+++ b/src/tests/itests/tools/dummy/xi_io_dummy_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/tests/itests/tools/dummy/xi_io_dummy_layer.h
+++ b/src/tests/itests/tools/dummy/xi_io_dummy_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_IO_DUMMY_LAYER_H__

--- a/src/tests/itests/tools/dummy/xi_io_dummy_layer_state.h
+++ b/src/tests/itests/tools/dummy/xi_io_dummy_layer_state.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_IO_DUMMY_LAYER_STATE_H__

--- a/src/tests/itests/tools/xi_itest_layerchain_ct_ml_mc.h
+++ b/src/tests/itests/tools/xi_itest_layerchain_ct_ml_mc.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_LAYERCHAIN_CT_ML_MC_H__

--- a/src/tests/itests/tools/xi_itest_layerchain_mqttlogic.h
+++ b/src/tests/itests/tools/xi_itest_layerchain_mqttlogic.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_LAYERCHAIN_MQTTLOGIC_LAYER_H__

--- a/src/tests/itests/tools/xi_itest_layerchain_tls.h
+++ b/src/tests/itests/tools/xi_itest_layerchain_tls.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_LAYERCHAIN_TLS_LAYER_H__

--- a/src/tests/itests/tools/xi_itest_mock_broker_layer.c
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_globals.h"

--- a/src/tests/itests/tools/xi_itest_mock_broker_layer.h
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_MOCK_BROKER_LAYER_H__

--- a/src/tests/itests/tools/xi_itest_mock_broker_layerchain.h
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layerchain.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_MOCKBROKER_LAYERCHAIN_H__

--- a/src/tests/itests/tools/xi_mock_layer_mqttlogic_next.c
+++ b/src/tests/itests/tools/xi_mock_layer_mqttlogic_next.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_mock_layer_mqttlogic_next.h"

--- a/src/tests/itests/tools/xi_mock_layer_mqttlogic_next.h
+++ b/src/tests/itests/tools/xi_mock_layer_mqttlogic_next.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_MOCK_LAYER_MQTTLOGIC_NEXT_H__

--- a/src/tests/itests/tools/xi_mock_layer_mqttlogic_prev.c
+++ b/src/tests/itests/tools/xi_mock_layer_mqttlogic_prev.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_mock_layer_mqttlogic_prev.h"

--- a/src/tests/itests/tools/xi_mock_layer_mqttlogic_prev.h
+++ b/src/tests/itests/tools/xi_mock_layer_mqttlogic_prev.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_MOCK_LAYER_MQTTLOGIC_PREV_H__

--- a/src/tests/itests/tools/xi_mock_layer_tls_next.c
+++ b/src/tests/itests/tools/xi_mock_layer_tls_next.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_mock_layer_tls_next.h"

--- a/src/tests/itests/tools/xi_mock_layer_tls_next.h
+++ b/src/tests/itests/tools/xi_mock_layer_tls_next.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_MOCK_LAYER_TLS_NEXT_H__

--- a/src/tests/itests/tools/xi_mock_layer_tls_prev.c
+++ b/src/tests/itests/tools/xi_mock_layer_tls_prev.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_mock_layer_tls_prev.h"

--- a/src/tests/itests/tools/xi_mock_layer_tls_prev.h
+++ b/src/tests/itests/tools/xi_mock_layer_tls_prev.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_MOCK_LAYER_TLS_PREV_H__

--- a/src/tests/itests/xi_itest_clean_session.c
+++ b/src/tests/itests/xi_itest_clean_session.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_itest_clean_session.h"

--- a/src/tests/itests/xi_itest_clean_session.h
+++ b/src/tests/itests/xi_itest_clean_session.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef XI_ITEST_CLEAN_SESSION_H

--- a/src/tests/itests/xi_itest_helpers.c
+++ b/src/tests/itests/xi_itest_helpers.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_itest_helpers.h"

--- a/src/tests/itests/xi_itest_helpers.h
+++ b/src/tests/itests/xi_itest_helpers.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef XI_ITEST_HELPERS_H

--- a/src/tests/itests/xi_itest_mqttlogic_layer.c
+++ b/src/tests/itests/xi_itest_mqttlogic_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_globals.h"

--- a/src/tests/itests/xi_itest_mqttlogic_layer.h
+++ b/src/tests/itests/xi_itest_mqttlogic_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_MQTTLOGIC_LAYER_H__

--- a/src/tests/itests/xi_itest_tls_error.c
+++ b/src/tests/itests/xi_itest_tls_error.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_backoff_status_api.h"

--- a/src/tests/itests/xi_itest_tls_error.h
+++ b/src/tests/itests/xi_itest_tls_error.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_TLS_ERROR_H__

--- a/src/tests/itests/xi_itest_tls_layer.c
+++ b/src/tests/itests/xi_itest_tls_layer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_globals.h"

--- a/src/tests/itests/xi_itest_tls_layer.h
+++ b/src/tests/itests/xi_itest_tls_layer.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_ITEST_TLS_LAYER_H__

--- a/src/tests/itests/xi_itests.c
+++ b/src/tests/itests/xi_itests.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #define XI_MOCK_TEST_PREPROCESSOR_RUN

--- a/src/tests/tools/xi_test_utils.h
+++ b/src/tests/tools/xi_test_utils.h
@@ -1,9 +1,9 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
- 
+
 #ifndef __XI_TEST_UTILS_H__
 #define __XI_TEST_UTILS_H__
 

--- a/src/tests/utests/platform/posix/xi_thread/xi_utest_platform_dispatcher.h
+++ b/src/tests/utests/platform/posix/xi_thread/xi_utest_platform_dispatcher.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/platform/posix/xi_thread/xi_utest_platform_thread.h
+++ b/src/tests/utests/platform/posix/xi_thread/xi_utest_platform_thread.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_critical_section_def.h"

--- a/src/tests/utests/platform/posix/xi_thread/xi_utest_platform_thread_workerthread.h
+++ b/src/tests/utests/platform/posix/xi_thread/xi_utest_platform_thread_workerthread.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_backoff.c
+++ b/src/tests/utests/xi_utest_backoff.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_basic_testcase_frame.c
+++ b/src/tests/utests/xi_utest_basic_testcase_frame.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_utest_basic_testcase_frame.h"

--- a/src/tests/utests/xi_utest_basic_testcase_frame.h
+++ b/src/tests/utests/xi_utest_basic_testcase_frame.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_connect.c
+++ b/src/tests/utests/xi_utest_connect.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_control_topic.c
+++ b/src/tests/utests/xi_utest_control_topic.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_core.c
+++ b/src/tests/utests/xi_utest_core.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_data_desc.c
+++ b/src/tests/utests/xi_utest_data_desc.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_datastructures.c
+++ b/src/tests/utests/xi_utest_datastructures.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_event_dispatcher.c
+++ b/src/tests/utests/xi_utest_event_dispatcher.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/tests/utests/xi_utest_event_dispatcher_timed.c
+++ b/src/tests/utests/xi_utest_event_dispatcher_timed.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/tests/utests/xi_utest_fs.c
+++ b/src/tests/utests/xi_utest_fs.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_fs_dummy.c
+++ b/src/tests/utests/xi_utest_fs_dummy.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_fs_memory.c
+++ b/src/tests/utests/xi_utest_fs_memory.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_fs_posix.c
+++ b/src/tests/utests/xi_utest_fs_posix.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_handle.c
+++ b/src/tests/utests/xi_utest_handle.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_helper_functions.c
+++ b/src/tests/utests/xi_utest_helper_functions.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 /*

--- a/src/tests/utests/xi_utest_helpers.c
+++ b/src/tests/utests/xi_utest_helpers.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_list.c
+++ b/src/tests/utests/xi_utest_list.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/tests/utests/xi_utest_memory_limiter.c
+++ b/src/tests/utests/xi_utest_memory_limiter.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_mqtt_codec_layer_data.c
+++ b/src/tests/utests/xi_utest_mqtt_codec_layer_data.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_mqtt_ctors_dtors.c
+++ b/src/tests/utests/xi_utest_mqtt_ctors_dtors.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_mqtt_logic_layer_subscribe.c
+++ b/src/tests/utests/xi_utest_mqtt_logic_layer_subscribe.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_mqtt_parser.c
+++ b/src/tests/utests/xi_utest_mqtt_parser.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_mqtt_serializer.c
+++ b/src/tests/utests/xi_utest_mqtt_serializer.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_protobuf_endianess.c
+++ b/src/tests/utests/xi_utest_protobuf_endianess.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stdio.h>

--- a/src/tests/utests/xi_utest_protobuf_engine.c
+++ b/src/tests/utests/xi_utest_protobuf_engine.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_publish.c
+++ b/src/tests/utests/xi_utest_publish.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_resource_manager.c
+++ b/src/tests/utests/xi_utest_resource_manager.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_rng.c
+++ b/src/tests/utests/xi_utest_rng.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_senml.c
+++ b/src/tests/utests/xi_utest_senml.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_senml_serialization.c
+++ b/src/tests/utests/xi_utest_senml_serialization.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_thread.h
+++ b/src/tests/utests/xi_utest_thread.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_thread_threadpool.h
+++ b/src/tests/utests/xi_utest_thread_threadpool.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_thread_util_actions.h
+++ b/src/tests/utests/xi_utest_thread_util_actions.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_UTEST_THREAD_UTIL_ACTIONS_H__

--- a/src/tests/utests/xi_utest_thread_workerthread.h
+++ b/src/tests/utests/xi_utest_thread_workerthread.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utest_timed_task.c
+++ b/src/tests/utests/xi_utest_timed_task.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/utests/xi_utests.c
+++ b/src/tests/utests/xi_utests.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "tinytest.h"

--- a/src/tests/xi_lamp_communication.h
+++ b/src/tests/xi_lamp_communication.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_LAMP_COMUNNICATION_H__

--- a/src/tests/xi_memory_checks.c
+++ b/src/tests/xi_memory_checks.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include "xi_memory_checks.h"

--- a/src/tests/xi_memory_checks.h
+++ b/src/tests/xi_memory_checks.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #ifndef __XI_MEMORY_CHECKS_H__

--- a/src/tests/xi_tt_testcase_management.h
+++ b/src/tests/xi_tt_testcase_management.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2003-2016, LogMeIn, Inc. All rights reserved.
  *
  * This is part of the Xively C Client library,
- * it is licensed under the BSD 3-Clause license. 
+ * it is licensed under the BSD 3-Clause license.
  */
 
 #include <stddef.h>


### PR DESCRIPTION
[ Description ]
Code reformat for copyright header in source to remove a traliing space.

[ JIRA ]
XCL-1864

[ Reviewer ]
atigyi

[ QA ]
Built examples and built with tests.

[ Release Notes ]
None.
