### PR TITLE
removed xi_debug.c from sources if this is not a debug build.

### DIFF
--- a/make/mt-config/mt-config
+++ b/make/mt-config/mt-config
@@ -49,7 +49,6 @@ ifneq (,$(findstring expose_fs,$(CONFIG)))
 endif
 
 ifneq (,$(findstring debug,$(TARGET)))
-	XI_DEBUG_BUILD ?= 1
 	XI_DEBUG_OUTPUT ?= 1
 	XI_DEBUG_ASSERT ?= 1
 	XI_DEBUG_EXTRA_INFO ?= 1
@@ -214,7 +213,7 @@ XI_SOURCES += $(wildcard ./src/*.c)
 XI_SOURCES += $(foreach layerdir,$(XI_SRCDIRS),\
 	$(wildcard $(layerdir)/*.c))
 
-ifndef XI_DEBUG_BUILD
+ifeq ($(XI_DEBUG_OUTPUT),0)
 XI_SOURCES := $(filter-out $(LIBXIVELY_SOURCE_DIR)/xi_debug.c, $(XI_SOURCES) )
 endif
 

--- a/src/libxively/xi_debug.c
+++ b/src/libxively/xi_debug.c
@@ -9,8 +9,6 @@
 #include "xi_debug.h"
 #include "xi_allocator.h"
 
-#if XI_DEBUG_OUTPUT
-
 void xi_debug_data_logger_impl( const char* msg, const xi_data_desc_t* data_desc )
 {
     char* tmp = xi_alloc( 1024 );
@@ -39,5 +37,3 @@ void xi_debug_data_logger_impl( const char* msg, const xi_data_desc_t* data_desc
 
     xi_free( tmp );
 }
-
-#endif /* XI_DEBUG_OUTPUT */


### PR DESCRIPTION
[ Description ]
Removed xi_debug.c from the source directories in release builds.  The entire contents of this file were being preprocessed out.

[ JIRA ]
XCL-2441: Ranlib build warning on MacOSX

[ Reviewer ]
atigyi

[ QA ]
built and linked examples with following configurations:
memory limiter on, debug and release
memory limiter off, debug and release.

[ Release Notes ]
Removed a ranlib build warning on OSX.
