### PR TITLE
Added info disclaimer and acknowledgement steps for TLS builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - "set -e"
   - "cd $HOME/build/xively/xively-client-c/"
   - "make PRESET=$PRESET XI_DEBUG_OUTPUT=0 $XI_MAKETARGET"
-  - expect "Do you wish to download this library from github? (Y) > " { send "Y\r" }
+  - "expect 'Do you wish to download this library from github? (Y) > ' { send "Y\r" }"
   - "if [ ! $CC == 'gcc' ]; then
         make -C examples/mqtt_logic_example  XI_CLIENT_LIB_PATH=../../bin/linux XI_BSP_TLS=$XI_BSP_TLS;
         make -C examples/mqtt_logic_producer XI_CLIENT_LIB_PATH=../../bin/linux XI_BSP_TLS=$XI_BSP_TLS;

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
       - clang-3.8
       - qemu-system
       - libc6:i386
+      - expect
 matrix:
   exclude:
     - compiler: clang
@@ -45,14 +46,13 @@ matrix:
     - compiler: clang
       env: PRESET=ARM_REL
     - compiler: clang
-      env: PRESET=CC3200_REL_MIN_UNSECURE XI_BSP_TLS="" XI_MAKETARGET=""
+      env: PRESET=CC3200_REL_MIN_UNSECURE XI_BSP_TLS="" XI_MAKETARGETXI_MAKETARGET=""
 before_script:
   - "if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi"
 script:
   - "set -e"
   - "cd $HOME/build/xively/xively-client-c/"
-  - "make PRESET=$PRESET XI_DEBUG_OUTPUT=0 $XI_MAKETARGET"
-  - "expect 'Do you wish to download this library from github? (Y) > ' { send "Y\r" }"
+  - "expect res/travis/travis_build.expect make PRESET=$PRESET XI_DEBUG_OUTPUT=0 $XI_MAKETARGET"
   - "if [ ! $CC == 'gcc' ]; then
         make -C examples/mqtt_logic_example  XI_CLIENT_LIB_PATH=../../bin/linux XI_BSP_TLS=$XI_BSP_TLS;
         make -C examples/mqtt_logic_producer XI_CLIENT_LIB_PATH=../../bin/linux XI_BSP_TLS=$XI_BSP_TLS;

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ script:
   - "set -e"
   - "cd $HOME/build/xively/xively-client-c/"
   - "make PRESET=$PRESET XI_DEBUG_OUTPUT=0 $XI_MAKETARGET"
+  - expect "Do you wish to download this library from github? (Y) > " { send "Y\r" }
   - "if [ ! $CC == 'gcc' ]; then
         make -C examples/mqtt_logic_example  XI_CLIENT_LIB_PATH=../../bin/linux XI_BSP_TLS=$XI_BSP_TLS;
         make -C examples/mqtt_logic_producer XI_CLIENT_LIB_PATH=../../bin/linux XI_BSP_TLS=$XI_BSP_TLS;

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
     - compiler: clang
       env: PRESET=ARM_REL
     - compiler: clang
-      env: PRESET=CC3200_REL_MIN_UNSECURE XI_BSP_TLS="" XI_MAKETARGETXI_MAKETARGET=""
+      env: PRESET=CC3200_REL_MIN_UNSECURE XI_BSP_TLS="" XI_MAKETARGET=""
 before_script:
   - "if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi"
 script:

--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,6 @@ $(XI): $(TLS_LIB_PATH) $(XI_PROTOFILES_C) $(XI_OBJS) | $(XI_BIN_DIRS)
 	$(info [$(AR)] $@ )
 	$(MD) $(AR) $(XI_ARFLAGS) $(XI_OBJS) $(XI_EXTRA_ARFLAGS)
 
-$(TLS_LIB_PATH):
-	$(TLS_LIB_PREPARE_CMD)
-
 # protobuf compilation
 $(XI_PROTOBUF_GENERATED)/%.pb-c.c : $(XI_PROTO_DIR)/%.proto
 	@-mkdir -p $(dir $@)

--- a/make/mt-config/mt-tls
+++ b/make/mt-config/mt-tls
@@ -16,9 +16,9 @@ TLS_LIB_PATH := $(LIBXIVELY_SRC)import/tls/$(XI_BSP_TLS)
 TLS_LIB_PREPARE_CMD := (cd $(LIBXIVELY_SRC)/import/tls/ && ./download_and_compile_$(XI_BSP_TLS).sh)
 
 $(TLS_LIB_PATH):
-	$(info ########################)
-	$(info # Xively Build Notice: #)
-	$(info ########################)
+	$(info ############################)
+	$(info # Xively TLS Build Notice: #)
+	$(info ############################)
 	$(info The Xively Client Build Configuration you're using includes )
 	$(info a third party TLS implementation XI_BSP_TLS: $(XI_BSP_TLS) )
 	$(info ) 

--- a/make/mt-config/mt-tls
+++ b/make/mt-config/mt-tls
@@ -14,3 +14,17 @@ XI_LIB_FLAGS += -L$(XI_TLS_LIB_BIN_DIR)
 
 TLS_LIB_PATH := $(LIBXIVELY_SRC)import/tls/$(XI_BSP_TLS)
 TLS_LIB_PREPARE_CMD := (cd $(LIBXIVELY_SRC)/import/tls/ && ./download_and_compile_$(XI_BSP_TLS).sh)
+
+$(TLS_LIB_PATH):
+	$(info --------------------)
+	$(info Xively Build Notice:)
+	$(info --------------------)
+	$(info The Xively Client Build Configuration you're using includes )
+	$(info a third party TLS implementation XI_BSP_TLS: $(XI_BSP_TLS) )
+	$(info ) 
+	$(info The Xively make system will download and build this TLS library for you. )
+	$(info )
+	$(info Please review the license information for your TLS library selection below )
+	$(info and check make help_tls for more information.)
+	$(info )
+	$(TLS_LIB_PREPARE_CMD)

--- a/make/mt-config/mt-tls
+++ b/make/mt-config/mt-tls
@@ -16,9 +16,9 @@ TLS_LIB_PATH := $(LIBXIVELY_SRC)import/tls/$(XI_BSP_TLS)
 TLS_LIB_PREPARE_CMD := (cd $(LIBXIVELY_SRC)/import/tls/ && ./download_and_compile_$(XI_BSP_TLS).sh)
 
 $(TLS_LIB_PATH):
-	$(info --------------------)
-	$(info Xively Build Notice:)
-	$(info --------------------)
+	$(info ########################)
+	$(info # Xively Build Notice: #)
+	$(info ########################)
 	$(info The Xively Client Build Configuration you're using includes )
 	$(info a third party TLS implementation XI_BSP_TLS: $(XI_BSP_TLS) )
 	$(info ) 

--- a/res/travis/travis_build.expect
+++ b/res/travis/travis_build.expect
@@ -5,12 +5,12 @@ set prompt "(%|#|\\$) $"
 eval spawn $argv
 
 expect {
-    "Please acknowledge these tool dependencies. Do you wish to proceed? " {
+    "Please acknowledge these tool dependencies. Do you wish to proceed?" {
       send -- "Y"
       exp_continue
     }
 
-    "Do you agree to the license of this third party library? (Y) " {
+    "Do you agree to the license of this third party library?" {
       send -- "Y"
       exp_continue
   }

--- a/res/travis/travis_build.expect
+++ b/res/travis/travis_build.expect
@@ -5,8 +5,13 @@ set prompt "(%|#|\\$) $"
 eval spawn $argv
 
 expect {
-  -re "TLS Download Response => " {
-    send -- "Y\r"
-    exp_continue
+    "Please acknowledge these tool dependencies. Do you wish to proceed? " {
+      send -- "Y"
+      exp_continue
+    }
+
+    "Do you agree to the license of this third party library? (Y) " {
+      send -- "Y"
+      exp_continue
   }
 }

--- a/res/travis/travis_build.expect
+++ b/res/travis/travis_build.expect
@@ -1,0 +1,12 @@
+#!/usr/bin/expect -f
+set timeout 300
+set prompt "(%|#|\\$) $"
+
+eval spawn $argv
+
+expect {
+  -re "TLS Download Response => " {
+    send -- "Y\r"
+    exp_continue
+  }
+}

--- a/src/import/tls/download_and_compile_mbedtls.sh
+++ b/src/import/tls/download_and_compile_mbedtls.sh
@@ -9,8 +9,7 @@ echo
 echo "the apache-2.0.txt file can be accessed here:"
 echo "   https://github.com/ARMmbed/mbedtls/blob/development/apache-2.0.txt"
 echo
-echo "Do you wish to download mbedTLS from github? (Y)"
-read -p "TLS Download Response => " -n 1 -r
+read -p "Do you agree to the license of this third party library? (Y) " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
@@ -24,6 +23,5 @@ cd mbedtls
 git checkout tags/mbedtls-2.3.0
 # "-O2" comes from mbedtls/library/Makefile "CFLAGS ?= -O2" define
 make CFLAGS="-O2 -DMBEDTLS_PLATFORM_MEMORY"
-cd ..
 echo "mbedTLS Build Complete."
 

--- a/src/import/tls/download_and_compile_mbedtls.sh
+++ b/src/import/tls/download_and_compile_mbedtls.sh
@@ -9,7 +9,8 @@ echo
 echo "the apache-2.0.txt file can be accessed here:"
 echo "   https://github.com/ARMmbed/mbedtls/blob/development/apache-2.0.txt"
 echo
-read -p "Do you wish to download this library from github? (Y) > " -n 1 -r
+echo "Do you wish to download mbedTLS from github? (Y)"
+read -p "TLS Download Response => " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then

--- a/src/import/tls/download_and_compile_mbedtls.sh
+++ b/src/import/tls/download_and_compile_mbedtls.sh
@@ -9,7 +9,7 @@ echo
 echo "the apache-2.0.txt file can be accessed here:"
 echo "   https://github.com/ARMmbed/mbedtls/blob/development/apache-2.0.txt"
 echo
-read -p "Do you agree to the license of this third party library? (Y) " -n 1 -r
+read -p "Do you agree to the license of this third party library? [Y/N] " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then

--- a/src/import/tls/download_and_compile_mbedtls.sh
+++ b/src/import/tls/download_and_compile_mbedtls.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
-
+echo
+echo "---------------"
+echo "mbedTLS LICENSE"
+echo "---------------"
+echo "Unless specifically indicated otherwise in a file, files are licensed"
+echo "under the Apache 2.0 license, as can be found in: apache-2.0.txt"
+echo
+echo "the apache-2.0.txt file can be accessed here:"
+echo "   https://github.com/ARMmbed/mbedtls/blob/development/apache-2.0.txt"
+echo
+read -p "Do you wish to download this library from github? (Y) > " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo
+    echo "exiting build.  run make help_tls for more information."
+    echo
+    exit 1
+fi
 git clone https://github.com/ARMmbed/mbedtls.git
 cd mbedtls
 git checkout tags/mbedtls-2.3.0
 # "-O2" comes from mbedtls/library/Makefile "CFLAGS ?= -O2" define
 make CFLAGS="-O2 -DMBEDTLS_PLATFORM_MEMORY"
 cd ..
-
-echo "Done"
+echo "mbedTLS Build Complete."
 

--- a/src/import/tls/download_and_compile_wolfssl.sh
+++ b/src/import/tls/download_and_compile_wolfssl.sh
@@ -7,13 +7,12 @@ echo "Please install the followng packages before proceeding:"
 echo
 echo "  MacOSX:"
 echo "    brew update"
-echo "    brew install autoconf automake libtool cmake"
+echo "    brew install autoconf automake libtool"
 echo "  Ubuntu:"
 echo "    sudo apt-get update"
 echo "    sudo apt-get install autoconf"
 echo "    sudo apt-get install autotools-dev"
 echo "    sudo apt-get install libtool"
-echo "    sudo apt-get install cmake"
 echo
 echo " For other TLS library options please run make help_tls."
 echo

--- a/src/import/tls/download_and_compile_wolfssl.sh
+++ b/src/import/tls/download_and_compile_wolfssl.sh
@@ -13,7 +13,8 @@ echo "Phone: +1 425 245-8247"
 echo
 echo "More information can be found on the wolfSSL website at www.wolfssl.com."
 echo
-read -p "Do you wish to download this library from github? (Y) > " -n 1 -r
+echo "Do you wish to download WolfSSL from github? (Y)"
+read -p "TLS Download Response => " -n 1 -r
 echo 
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then

--- a/src/import/tls/download_and_compile_wolfssl.sh
+++ b/src/import/tls/download_and_compile_wolfssl.sh
@@ -1,5 +1,36 @@
 #!/bin/bash
 echo
+echo "!! IMPORTANT !!"
+echo
+echo "WolfSSL's build system requires autotools to be installed on your host system."
+echo "Please install the followng packages before proceeding:"
+echo
+echo "  MacOSX:"
+echo "    brew update"
+echo "    brew install autoconf automake libtool cmake"
+echo "  Ubuntu:"
+echo "    sudo apt-get update"
+echo "    sudo apt-get install autoconf"
+echo "    sudo apt-get install autotools-dev"
+echo "    sudo apt-get install libtool"
+echo "    sudo apt-get install cmake"
+echo
+echo " For other TLS library options please run make help_tls."
+echo
+echo " ! If you proceed from this step the build fails then you will need to: !"
+echo "    1: make clean_all"
+echo "    2: rm -rf src/import/tls/wolfssl"
+echo
+read -p "Please acknowledge these tool dependencies. Do you wish to proceed? (Y) " -n 1 -r
+echo 
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo
+    echo "Exiting build."
+    echo
+    exit 1
+fi
+echo
 echo "-----------------"
 echo "WolfSSL LICENSING"
 echo "-----------------"
@@ -13,8 +44,7 @@ echo "Phone: +1 425 245-8247"
 echo
 echo "More information can be found on the wolfSSL website at www.wolfssl.com."
 echo
-echo "Do you wish to download WolfSSL from github? (Y)"
-read -p "TLS Download Response => " -n 1 -r
+read -p "Do you agree to the license of this third party library? (Y) " -n 1 -r
 echo 
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then

--- a/src/import/tls/download_and_compile_wolfssl.sh
+++ b/src/import/tls/download_and_compile_wolfssl.sh
@@ -1,8 +1,30 @@
 #!/bin/bash
-
+echo
+echo "-----------------"
+echo "WolfSSL LICENSING"
+echo "-----------------"
+echo "wolfSSL (formerly known as CyaSSL) and wolfCrypt are either licensed for use"
+echo "under the GPLv2 or a standard commercial license. For our users who cannot use"
+echo "wolfSSL under GPLv2, a commercial license to wolfSSL and wolfCrypt is available."
+echo "Please contact wolfSSL Inc. directly at:"
+echo
+echo "Email: licensing@wolfssl.com"
+echo "Phone: +1 425 245-8247"
+echo
+echo "More information can be found on the wolfSSL website at www.wolfssl.com."
+echo
+read -p "Do you wish to download this library from github? (Y) > " -n 1 -r
+echo 
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo
+    echo "Exiting build.  Run make help_tls for more information."
+    echo
+    exit 1
+fi
 git clone https://github.com/wolfSSL/wolfssl
 cd wolfssl
 git checkout tags/v3.9.6
 (autoreconf --install && ./configure `cat ../wolfssl.conf` && make)
-echo "Done"
+echo "WolfSSL Build Complete."
 

--- a/src/import/tls/download_and_compile_wolfssl.sh
+++ b/src/import/tls/download_and_compile_wolfssl.sh
@@ -20,7 +20,7 @@ echo " ! If you proceed from this step and the build fails then you will need to
 echo "    1: make clean_all"
 echo "    2: rm -rf src/import/tls/wolfssl"
 echo
-read -p "Please acknowledge these tool dependencies. Do you wish to proceed? (Y) " -n 1 -r
+read -p "Please acknowledge these tool dependencies. Do you wish to proceed? [Y/N] " -n 1 -r
 echo 
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
@@ -43,7 +43,7 @@ echo "Phone: +1 425 245-8247"
 echo
 echo "More information can be found on the wolfSSL website at www.wolfssl.com."
 echo
-read -p "Do you agree to the license of this third party library? (Y) " -n 1 -r
+read -p "Do you agree to the license of this third party library? [Y/N] " -n 1 -r
 echo 
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then

--- a/src/import/tls/download_and_compile_wolfssl.sh
+++ b/src/import/tls/download_and_compile_wolfssl.sh
@@ -16,7 +16,7 @@ echo "    sudo apt-get install libtool"
 echo
 echo " For other TLS library options please run make help_tls."
 echo
-echo " ! If you proceed from this step the build fails then you will need to: !"
+echo " ! If you proceed from this step and the build fails then you will need to: !"
 echo "    1: make clean_all"
 echo "    2: rm -rf src/import/tls/wolfssl"
 echo


### PR DESCRIPTION
[ Description ]
Added an user interaction step for TLS library download to confirm the license of the 3rd party TLS implementation and to directly notify that customers will need to install autotools to build WolfSSL.

[ JIRA ]
XCL-2501

[ Reviewer ]
atigyi
olgierdh 

[ QA ]
Built client with both TLS versions.
Built with make tests
Travis CI builds pass.

[ Release Notes ]
Users will now be prompted with much more descriptive text when building with TLS support.