### PR TITLE
Feature/porting guide edits

### DIFF
--- a/doc/porting_guide.md
+++ b/doc/porting_guide.md
@@ -3,7 +3,7 @@
 
 ## Table of Contents
 1. [Target Audience](#target-audience)
-2. [Xively Client versions](#xively-client-versions)
+2. [C Client Overview](#c-client-overview)
 3. [Supported Platforms](#supported-platforms)
 4. [Board Support Package (BSP)](#board-support-package-bsp)
 5. [Porting the C Client](#porting-the-c-client)
@@ -17,32 +17,20 @@ This document is intended for Embedded Developers who have access to the source 
 
 Details of the Xively C Client build steps, build configuration flags, and the location of the functions needed to port the library to new platforms are included in this document.
 
-## Xively Client Versions
+For information about the Xively Python client, please visit its public git repository: [xiPy](https://github.com/xively/xipy).
 
-#### C Client
+## C Client Overview
 
-The C Client is designed for low resources platforms. The single threaded implementation is non-blocking, which allows it to operate on NoOs platforms. The implementation also supports seamless concurrent processing of outgoing and incoming messages.
+The Xively C Client is designed for low resources platforms. The single threaded implementation is non-blocking, which allows it to operate on NoOs platforms. The implementation also supports seamless concurrent processing of outgoing and incoming messages.
 
-An event system is also included for Xively C Client scheduling, but it can also be used by your client application as well. It's a platform independant implementation that doesn't require porting to any platform-specific timers or tasks.
+An event system is included in the client which can be used by your client application as well. The client's event system is a platform independant implementation that doesn't require porting to any platform-specific timers or tasks.
 
 The client provides this functionality while remaining small enough to reside on low resource MCUs, consumes minimal memory, processor power and energy consumption.
 
 The codebase is built against C99 standards.
 
-For more information place see the Xively C Client user guide in the Xively Developer Center.
+For more information please see the Xively C Client User Guide: `doc/user_guide.md`.
 
-#### Python Client
-
-The Python Client is meant for platforms where Python interpreter is available and it allows you to skip the C Client Porting Process for those platforms.
-
-Typically this is where there's no need for low resource consumption and where battery power or energy consumption is not a bottleneck.
-
-Python 2.7 and 3.4+ are both supported.
-
-The development version of the Xively Python Client is in seperate repository under xi_client_py.  A release version of this same source-base is accessible in two ways:
-
-- pip install xiPy OR
-- public git repository: [xiPy](https://github.com/xively/xipy)
 
 ## Supported Platforms
 

--- a/doc/porting_guide.md
+++ b/doc/porting_guide.md
@@ -458,23 +458,24 @@ While we cannot completely predict how this process would work for every IDE and
   Using the CONFIG flags in file `make/mt-config/mt-config` as a guide, the compiler flags used in the "Preceding Step" can be looked up and fed to the platform specific build system as well. Another option is to echo the makefile build system variable XI_CONFIG_FLAGS during building on OSX to see which flags are set.
 
 
-## Xively Client Features
+## Further Reading
+For more informationa about the Xively Client, check these other documents in the [github repository](https://github.com/xively/xively-client-c):
 
-#### TLS
 
-The Xively C Client brings its own secure connection solution suitable for multiple
-platforms. In order to provide TLSv1.2 secure communication with Xively servers -
-Xively Client exposes BSP TLS with reference implementations against [WolfSSL's TLS](https://www.wolfssl.com/wolfSSL/Home.html) and [mbed TLS](https://tls.mbed.org/) libraries.
+### README.md
 
-If you do not have a Xively Client compiled for you by Xively Professional Services, then you will need to compile a TLS implementation yourself.
+Contains general information about the file structure of the sources, how to build on OSX and Linux,  a general overview of Security.
 
-#### Back-off logic
+### doc/UserGuide.md
 
-Xively Clients has accidental Distributed Denial of Service protection logic (DDoS) built into the library itself, which we call Back-off logic. This logic randomly spreads out reconnection attempts based on the number of recently failed connection attempts.  The goal is to prevent all of the devices choking the Xively Service in the rare case that there was a massive networking outage.
+Contains an in-depth description of the Client Design and IoT Features, including MQTT logic, Event System, Back-Off Logic, Platform Security Requirements, etc.
 
-Xively Servers may ban clients which don't keep the rules of Back-off's delayed reconnection. To avoid banning your devices, please DO NOT alter this Back-off logic.
+### doxygen/api 
 
-#### Control Topic
+Contains the function specifications for communicating with the Xively C Client from our application.  Functionality such as Connect, Subscribe, and Publish are outlined here.
 
-This is a Xively Client specific feature. Currently this consist of a single step: subscription
-to a control topic at the beginning of the connection.  More features are coming soon.
+
+### doxygen/bsp
+
+Contains the declarations and documentations of the abstracted Board Support Package functions that you will need to implement to couple the Xively C Client to your hardware platform.
+

--- a/doc/porting_guide.md
+++ b/doc/porting_guide.md
@@ -41,6 +41,7 @@ The Xively Client has been deployed on many different devices already shipping i
   - WMSDK
   - Texas Instruments CC3200
   - STM3241G-EVAL
+  - Marvell
 
 Porting the Xively C Client to new platforms is accelerated by the Board Support Package (BSP). 
 
@@ -317,7 +318,7 @@ The examples are command line applications libxively links against. They require
 
 #### Let's Begin
 
-As a rule of thumb if you are stuck or confused, then please user existing platform config files like: `make/mt-os/mt-cc3200` or `make/mt-os/mt-linux` files as an example.
+As a rule of thumb if you are stuck or confused, then please use existing platform config files like: `make/mt-os/mt-cc3200` or `make/mt-os/mt-linux` files as an example.
 
 Let's assume the new platform's name is np2000. 
 
@@ -378,7 +379,7 @@ To make this possible, the following steps have to be taken.
                 XI_BSP_PLATFORM = np2000
                 XI_TARGET_PLATFORM = np2000
 
-- [x] extend `make/mt-os/mt-os` to check the TARGET make parameter for 'np2000' and include the `make/mt-os/mt-np2000` config file when the np200 TARGET is found:
+- [x] extend `make/mt-os/mt-os` to check the TARGET make parameter for 'np2000' and include the `make/mt-os/mt-np2000` config file when the np2000 TARGET is found:
 
         XI_CONST_PLATFORM_NP2000 := np2000
 
@@ -438,8 +439,12 @@ While we cannot completely predict how this process would work for every IDE and
 	- NOTE: The Xively C Client contains reference BSP implementations for POSIX and CC3200. We also have partial implementations for specific networking APIs. 
     Modules from these 'incomplete' BSP implementations could be used as substitutes. For instance, on devices that mirror POSIX completely except for networking, like Simplelink, the networking module from `src/bsp/platform/posix` could be ovewritten with the one from `src/bsp/platform/simplelink_incomplete`. 
 - import one of the BSP TLS implementations in `src/bsp/tls`.  Currently we provide two different TLS BSP implementations: WolfSSL or mbedTLS.
-- add all of the directories in `src/libxively` to your include path
-- add the `include` directory in the base of the sources to your include path
+
+
+- alter the include path for the toolchain.
+	- add all of the directories in `src/libxively` to your include path
+	- add the `include` directory to your include path
+	- add the `include/bsp` directory to your include path
 - add any corresonding preprocessor defintions to toggle on/off Xively client features. 
   Using the CONFIG flags in file `make/mt-config/mt-config` as a guide, the compiler flags used in the "Preceding Step" can be looked up and fed to the platform specific build system as well. Another option is to echo the makefile build system variable XI_CONFIG_FLAGS during building on OSX to see which flags are set.
 

--- a/doc/porting_guide.md
+++ b/doc/porting_guide.md
@@ -172,7 +172,7 @@ Run command
 
 Alternatively one can use mbedTLS instead of wolfSSL if preferred:
 
-	make XI_BSP_TLS=mbedTLS
+	make XI_BSP_TLS=mbedtls
 
 Occasionally cleaning the build directories are necessary. This is done with either of the following commands:
 
@@ -404,7 +404,7 @@ To make this possible, the following steps have to be taken.
     - the default selection is wolfssl.  If wolfssl fits your needs then there's nothing to do here.
     - to select a different TLS lib add
 
-            XI_BSP_TLS=mbedTLS
+            XI_BSP_TLS=mbedtls
 
         or
 

--- a/doc/porting_guide.md
+++ b/doc/porting_guide.md
@@ -166,27 +166,26 @@ Firing a bare `make` should be enough for an OSX build. It defaults to *posix* p
 
 Run command
 
-`make`
+	`make`
 
 Alternatively one can use mbedTLS instead of wolfSSL if preferred:
 
-`make XI_BSP_TLS=mbedTLS`
+	make XI_BSP_TLS=mbedTLS
 
-Occasionally cleaning the build directories are necessary. This is done with the commands
+Occasionally cleaning the build directories are necessary. This is done with either of the following commands:
 
-`make clean`
-    OR
-`make clean_all`
+	make clean
+	make clean_all
 
 ##### Building the Examples
+From the base directory of the repository:
 
-`cd examples`
+	cd examples
+	make
 
-`make`
+Here if the library was previously built with the mbedTLS setting then the XI_BSP_TLS variable is necessary.  Otherwise you will get link errors.
 
-here if previously library was built with mbedTLS setting the XI_BSP_TLS variable is necessary to tell the linker which TLS lib to link agains:
-
-`make XI_BSP_TLS=mbedTLS`
+	make XI_BSP_TLS=mbedTLS
 
 
 #### Build Dependencies

--- a/doc/porting_guide.md
+++ b/doc/porting_guide.md
@@ -105,7 +105,7 @@ To create a new BSP implementation for TLS:
 - copy the file `make/mt-config/mt-tls-wolfssl.mk` to `make/mt-config/mt-tls-[NEW_TLS_LIBRARY_NAME].mk` and set the path variables inside according to the new TLS library's internal directory structure
 - call `make` with parameter `XI_BSP_TLS=[NEW_TLS_LIBRARY_NAME]`
 
-#### Customising Both: Platform and TLS BSPs
+#### Customizing Both: Platform and TLS BSPs
 
 Invoking `make` without parameters will silently default the configuration to `make XI_BSP_PLATFORM=posix XI_BSP_TLS=wolfssl`. 
 
@@ -244,7 +244,7 @@ A typical TARGET flag looks like this:
 
 A typical CONFIG flag:
 
-    posix_io-posix_fs-thread_module-posix_platform-tls-senml-memory_limiter
+    posix_io-posix_fs-posix_platform-tls-senml-memory_limiter
 
 ###### Xively Client Feature flags
 
@@ -282,6 +282,12 @@ A typical CONFIG flag:
     - posix_platform    - selects implementation for non-BSP time and non-BSP memory solutions
     - wmsdk_platform    - selects implementation for non-BSP time and non-BSP memory solutions
 
+The Platform Selector configurations will eventually be sunset.  Currently these configure the build system to include Critical Section implementations for invoking callbacks on new threads.  
+
+We suggest defining `posix_platform` and omit `threading` from your CONFIG options when building for custom platforms.  `threading` is currently ommitted by default.
+
+For more information about thread safe callback support please see the Xively C Client User Guide: `doc/user_guide.md`.
+
 #### Example make Command
 
 By executing a simple 'make' under directory xi\_client\_c should be sufficient on OSX or Linux/Unix. This will result in build configuration with the following default flags:
@@ -305,14 +311,6 @@ For CI configurations please look at the file [.travis.yml](../../.travis.yml).
 Example application binaries can be found under directory `examples`
 These examples use the Xively C Client library for connecting to Xively Servers, subscribing to topics, and sending and receiving data.
 The examples are command line applications libxively links against. They require a Xively-specific account-id, username, password and optional topicname to subscribe or publish on.
-
-##### _XI_BSP_PLATFORM_
-
-    - [ posix | cc3200 | ... ] - selects the bsp implementation from the available implementations, by default this flag is set to posix platform
-
-##### _XI_BSP_TLS_
-
-    - [ wolfssl | mbedtls ] - selects the TLS library which is used to provide secure connection with Xively servers, WolfSSL is set by default
 
 ### Porting the Xively C Client to Your Platform
 

--- a/doc/porting_guide.md
+++ b/doc/porting_guide.md
@@ -245,7 +245,7 @@ A typical TARGET flag looks like this:
 
 A typical CONFIG flag:
 
-	bsp_posix-posix_fs-posix_platform-tls-senml-control_topic-memory_limiter
+	bsp_posix-posix_fs-posix_platform-tls_bsp-senml-control_topic-memory_limiter
 
 ###### Xively Client Feature flags
 
@@ -274,7 +274,7 @@ A typical CONFIG flag:
     - mqtt_localhost    - the Client will connect to localhost MQTT server. The purpose of this configuration option
                           is to help development processes.
     - no_certverify     - lowers security by disabling TLS certificate verification
-    - tls               - the Client will use third party TLS 1.2 implementations to encrypt data before it's sent over network sockets.   
+    - tls_bsp           - the Client will use third party TLS 1.2 implementations to encrypt data before it's sent over network sockets.   
 					      The lack of this flag will skip the TLS handshaking.  This be may helpful in connecting to mosquitto to test,
                           but may not be supported on some secure services and is not recommend for production
                           deployment.  The Xively Gateway will not accept connections without TLS.
@@ -316,7 +316,7 @@ The examples are command line applications libxively links against. They require
 
 #### Let's Begin
 
-As a rule of thumb if you are stuck or confused, then please use existing platform config files like: `make/mt-os/mt-cc3200` or `make/mt-os/mt-linux` files as an example.
+As a rule of thumb if you are stuck or confused, then please use existing platform config files like: `make/mt-os/mt-cc3200` or `make/mt-os/mt-linux` files as examples.
 
 Let's assume the new platform's name is np2000. 
 
@@ -404,7 +404,7 @@ To make this possible, the following steps have to be taken.
     - the default selection is wolfssl.  If wolfssl fits your needs then there's nothing to do here.
     - to select a different TLS lib add
 
-            XI_BSP_TLS=mbedtls
+            XI_BSP_TLS=mbedTLS
 
         or
 

--- a/doc/porting_guide.md
+++ b/doc/porting_guide.md
@@ -259,7 +259,6 @@ A typical CONFIG flag:
     - posix_fs          - POSIX implementation of File System calls
     - memory_fs         - an in-memory File System implementation
     - dummy_fs          - empty implementation of File System calls
-
     - expose_fs         - adds a new Xively C Client API function which allows external definition
                           of File System calls.  This will be part of our BSP system in the future.
 

--- a/doc/porting_guide.md
+++ b/doc/porting_guide.md
@@ -9,7 +9,7 @@
 5. [Porting the C Client](#porting-the-c-client)
     - [Suggested First Step - A Native Build](#suggested-first-step---a-native-build)
     - [Porting the Xively C Client to Your Platform](#porting-the-xively-c-client-to-your-platform)
-6. [Xively Client Features](#xively-client-features)
+6. [Further Reading](#further-reading)
 
 
 ## Target Audience
@@ -25,7 +25,7 @@ The Xively C Client is designed for low resources platforms. The single threaded
 
 An event system is included in the client which can be used by your client application as well. The client's event system is a platform independant implementation that doesn't require porting to any platform-specific timers or tasks.
 
-The client provides this functionality while remaining small enough to reside on low resource MCUs, consumes minimal memory, processor power and energy consumption.
+The client provides this functionality while remaining small and efficient enough to fit into low-resource devices, with minimal footprint and processing power requirements.
 
 The codebase is built against C99 standards.
 
@@ -52,18 +52,18 @@ We've organized the sources of the Xivey Client so that your BSP implementation 
 
 The BSP was designed to minimize the time it takes to make a port of the library. With it an engineer can ignore the MQTT codec or the non-blocking / asynchronous engine that resides in the main library source.
 
-All of the BSP **function declarations** can be found under the _xi\_client\_c/include/bsp_
-directory. Doxygen documentation for these functions can be found in the _doc/doxygen/bsp/html/index.html_. 
+All of the BSP **function declarations** can be found under the `include/bsp`
+directory. Doxygen documentation for these functions can be found in the `doc/doxygen/bsp/html/index.html`.
 
 BSP Functions are broken down by logical subsystem as follows:
 
 ### BSP Modules
 
-- BSP IO NET: Networking Stack Integration (xi\_bsp\_io\_net.h)
-- BSP TLS: Transport Layer Security Integration (xi\_bsp\_tls.h)
-- BSP MEM: Heap Memory Management (xi\_bsp\_mem.h)
-- BSP RNG: Random Number Generator (xi\_bsp\_rng.h)
-- BSP TIME: Time Function (xi\_bsp\_time.h)
+- BSP IO NET: Networking Stack Integration (`include/bsp/xi_bsp_io_net.h`)
+- BSP TLS: Transport Layer Security Integration (`include/bsp/xi_bsp_tls.h`)
+- BSP MEM: Heap Memory Management (`include/bsp/xi_bsp_mem.h`)
+- BSP RNG: Random Number Generator (`include/bsp/xi_bsp_rng.h`)
+- BSP TIME: Time Function (`include/bsp/xi_bsp_time.h`)
 
 ### Reference Implementations
 
@@ -112,9 +112,9 @@ This is fine for building on OSX or Linux/Unix using wolfSSL for a TLS library. 
 
 	`make XI_BSP_PLATFORM=cc3200 XI_BSP_TLS=microSSL`
 
-*Note: microSSL is a fictional TLS library we conjured up as a quick custom example.*
+*Note: microSSL is a fictional TLS library we've conjured-up as a quick custom example.*
 
-This command assumes directory *src/bsp/platform/cc3200* containing networking, memory, random and time implementations as well as directory *src/bsp/tls/microSSL* covering the TLS calls.  
+This command assumes directory `src/bsp/platform/cc3200*` containing networking, memory, random and time implementations as well as directory `src/bsp/tls/microSSL` covering the TLS calls.  
 
 
 ## Porting the C Client
@@ -123,11 +123,11 @@ Building a Xively C Client consists of building the Xively C Client *library*, t
 
 ### Suggested First Step - A Native Build
 
-We recommend building the Xively Client on OSX or Linux/Unix before attempting to cross compile the sources to another target platform. This process could serve as an introduction to the basic architecture, tools and building stepos of the Xively Client source. This basic knowledge will be handy later when doing a full cross-compiled port of the software to an embedded device.
+We recommend building the Xively Client on OSX or Linux/Unix before attempting to cross compile the sources to another target platform. This process could serve as an introduction to the basic architecture, tools and building steps of the Xively Client source. This basic knowledge will be handy later when doing a full cross-compiled port of the software to an embedded device.
 
 #### Build System: make
 
-The Xively C Client uses _make_ to build for OSX or Linux/Unix. The main makefile is root directory of the repository. 
+The Xively C Client uses _make_ to build for OSX or Linux/Unix. The main makefile is in the root directory of the repository. 
 
 Further build configurations can be found under directory `make/` which contains numerous make target (mt) files which are included by the main makefile. Here `make/mt-config/mt-config` and `make/mt-os/mt-os` files should be your main focus.  These are always included by the main makefile, and further include optional mt files based on the CONFIG and TARGET flags you specify when building.  
 
@@ -198,7 +198,7 @@ On OSX these are available through `brew`:
     - brew install autoconf
     - brew install automake
     - brew install libtool
-    - brew install cmak
+    - brew install cmake
 
 On Ubuntu these are available through `apt-get`:
 	
@@ -206,6 +206,7 @@ On Ubuntu these are available through `apt-get`:
 	- sudo apt-get install autoconf
 	- sudo apt-get install autotools-dev
 	- sudo apt-get install libtool
+	- sudo apt-get install cmake
    
 
 #### Xively C Client Build Flags
@@ -218,7 +219,7 @@ CONFIG flags specify selections from a list of Xively Client modules and feature
 
 _Default_ values will be chosen for you if you do not set the TARGET or CONFIG makefile variables.
 
-The TARGET and CONFIG flags are enumerated below, and can be mixed and matched in any order.  Each flag isseparated by the - (minus sign / dash) character.
+The TARGET and CONFIG flags are enumerated below, and can be mixed and matched in any order.  Each flag is separated by the - (minus sign / dash) character.
 
 ##### TARGET Flags
 
@@ -250,7 +251,7 @@ A typical CONFIG flag:
                           Currently activating this feature has no behavioral benefit.
     - senml             - turns on SENML JSON serialization support for timeseries data. To maintain a small
                           footprint size we recommend turning this off (by removing senml flag from CONFIG).
-    - threading         - POSIX only.  This turns causes pplication callbacks to be called on separate thread.
+    - threading         - POSIX only.  This turns causes application callbacks to be called on separate thread.
                           Not having this flag set application callbacks are called on the sole main
                           thread of the Xively C Client.
 
@@ -271,9 +272,9 @@ A typical CONFIG flag:
                           is to help development processes.
     - no_certverify     - lowers security by disabling TLS certificate verification
     - tls               - the Client will use third party TLS 1.2 implementations to encrypt data before it's sent over network sockets.   The lack of this
-                          flag will skip the TLS handshaking.  This may helpful in connecting to mosquitto to test,
+                          flag will skip the TLS handshaking.  This be may helpful in connecting to mosquitto to test,
                           but may not be supported on some secure services and is not recommend for production
-                          deployment.  The Xively Gateway will not accepts connections without TLS.
+                          deployment.  The Xively Gateway will not accept connections without TLS.
 
 ###### Platform selector flags
 
@@ -300,9 +301,8 @@ For CI configurations please look at the file [.travis.yml](../../.travis.yml).
 
 #### Example Xively Client Applications Linked with the Library
 
-Example application binaries can be found under directory _xi\_client\_c/src/examples_.
-These examples use of the Xively C Client library for connecting to Xively Servers,
-subscribing to topics, and sending and receiving data.
+Example application binaries can be found under directory `examples`
+These examples use the Xively C Client library for connecting to Xively Servers, subscribing to topics, and sending and receiving data.
 The examples are command line applications libxively links against. They require a Xively-specific account-id, username, password and optional topicname to subscribe or publish on.
 
 ##### _XI_BSP_PLATFORM_
@@ -324,7 +324,7 @@ Let's assume the new platform's name is np2000.
 
 #### The Goal: Cross Compilation with the _make_ Build System
 
-The ideal goal to cross-compile the Xively C Client on OSX or Linux/Unix to your platform.  For the sake of this tutorial, let's pretend that your platform is a new fictitious platform: The *NP2000*.  You'r platform sounds awesome.
+The ideal goal to cross-compile the Xively C Client on OSX or Linux/Unix to your platform.  For the sake of this tutorial, let's pretend that your platform is a new fictitious platform: The *NP2000*.  Your platform sounds awesome.
 
 Our goal is construct the following command to build the Xively Client for the NP2000:
 
@@ -402,7 +402,7 @@ To make this possible, the following steps have to be taken.
     Hint: to reach successful build just create the files and implement all the BSP API functions with **empty body**.  While this wont execute properly, it should link and run.
 
 - [x] select TLS implementation
-    - the default seelction is wolfssl.  If wolfssl fits the needs then nothing to do here.
+    - the default selection is wolfssl.  If wolfssl fits your needs then there's nothing to do here.
     - to select a different TLS lib add
 
             XI_BSP_TLS=mbedtls


### PR DESCRIPTION
[ Description ]
Revised Porting Guide with updates to the build process and to make it more concise.

- Updated the version of the porting guide to fall in line with the formatting of source paths of our upcoming CC3200 Tutorial.
- Removed section about Python Client, instead directing the reader to the xiPy Repository.
- Removed references of the xi_client_c path that remained since before we switched repos.
- Added full paths to files where they would have been helpful
- Condensed sections to make the document more concise.
- Added a new Further Reading section to the bottom of the document.
- Updated TLS config flag to use the new tls_bsp nomenclature. 

[ Reviewer ]
@atigyi 
@olgierdh 

[ QA ]
Ensured anchor links work

[ Release Notes ]
Revised Porting Guide to make it more clear and concise.
