### PR TITLE
[fix] added missing sl_Close for simplelink socket

### DIFF
--- a/src/bsp/platform/cc3200/xi_bsp_io_net_cc3200.c
+++ b/src/bsp/platform/cc3200/xi_bsp_io_net_cc3200.c
@@ -232,7 +232,7 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
 
 xi_bsp_io_net_state_t xi_bsp_io_net_close_socket( xi_bsp_socket_t* xi_socket )
 {
-    ( void )xi_socket;
+    sl_Close( *xi_socket );
 
     return XI_BSP_IO_NET_STATE_OK;
 }


### PR DESCRIPTION
[DESCRIPTION]
Fix for CC3200 bsp io net implementation. We didn't close the simplelink socket. 

[JIRA]
XCL-2595 Socket Descriptor Leak on CC3200

[REVIEWER]
@atigyi 
@DellaBitta

[QA]
Tests performed on CC3200 setting the application to reconnect every random timeout in range from 5 to 30 seconds.

[RELEASE NOTES]
Fixed a socket descriptor leak on the CC3200.