### PR TITLE
Removed auto generated folder from make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ buildtime:
 clean:
 	$(RM) -rf \
 		$(XI_BINDIR) \
-		$(XI_PROTOBUF_GENERATED) \
 		$(XI_OBJDIR) \
 		$(XI_TEST_OBJDIR) \
 		$(filter-out %.o %.a %import,$(wildcard $(XI_OBJDIR)/*))


### PR DESCRIPTION
[DESCRIPTION]
Removed folder with generated protobuf files from the Makefile clean since these files are part of the git repository. It removes the confusion around creating commits when these files where deleted due to execution of ```make clean```

[REVIEWERS]
@DellaBitta

[JIRA]
https://jira.3amlabs.net/browse/XCL-2615

[QA]
Didn't affect the QA process.

[RELEASE NOTES]
Calling ```make clean``` will no longer remove the folder that contains protobuf auto generated files.
