### PR TITLE
Remove link to wolfssl library from xively demo

### DIFF
--- a/examples/cc3200/xively_demo/.cproject
+++ b/examples/cc3200/xively_demo/.cproject
@@ -76,7 +76,6 @@
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_15.12.linkerID.LIBRARY.1886200684" name="Include library file or command file as input (--library, -l)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_15.12.linkerID.LIBRARY" valueType="libs">
 									<listOptionValue builtIn="false" value="&quot;libc.a&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${XIVELY_LIBRARY_C_ROOT}/bin/cc3200/libxively.a&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${XIVELY_LIBRARY_C_ROOT}/src/import/tls/wolfssl/tirtos/packages/ti/net/wolfssl/lib/wolfssl.aem4f&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${CC3200_SDK_ROOT}/simplelink/ccs/NON_OS/simplelink.a&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${CC3200_SDK_ROOT}/driverlib/ccs/Release/driverlib.a&quot;"/>
 								</option>


### PR DESCRIPTION
[DESCRIPTION]
We don't need and we don't want wolfssl library to be linked against our xively demo example for CC3200 since the xively demo is using on board TLS implementation. 

[REVIEWERS]
@DellaBitta 

[QA]
Tested building of xively demo without compiled wolfssl library.

[RELEASE NOTES]
N/A