### PR TITLE
Feature/add clang static analysis target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *~
 *.zip
 *.pyc
+*.log
 
 obj/
 bin/

--- a/Makefile
+++ b/Makefile
@@ -191,9 +191,11 @@ endif
 .PHONY: static_analysis
 static_analysis:  $(XI_SOURCES:.c=.sa)
 
+NOW:=$(shell date +"%F-%T")
+
 $(LIBXIVELY)/src/%.sa:
 	$(info [clang-tidy] $(@:.sa=.c))
-	@clang-tidy --checks='clang-analyzer-*,-clang-analyzer-cplusplus*,-clang-analyzer-osx*' $(@:.sa=.c) >> static_analysis.log -- $(XI_CONFIG_FLAGS) $(XI_COMPILER_FLAGS) $(XI_INCLUDE_FLAGS)
+	@clang-tidy --checks='clang-analyzer-*,-clang-analyzer-cplusplus*,-clang-analyzer-osx*' $(@:.sa=.c) >> static_analysis_$(NOW).log -- $(XI_CONFIG_FLAGS) $(XI_COMPILER_FLAGS) $(XI_INCLUDE_FLAGS)
 
 $(XI_BIN_DIRS):
 	@mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,12 @@ $(XI_ITESTS): $(XI) $(CMOCKA_LIBRARY_DEPS) $(XI_ITEST_OBJS)
 
 endif
 
+.PHONY: static_analysis
+static_analysis:  $(XI_SOURCES:.c=.sa)
+
+$(LIBXIVELY)/src/%.sa:
+	$(info clang-tidy --checks='clang-analyzer-*,-clang-analyzer-cplusplus*,-clang-analyzer-osx*' $(@:.sa=.c)) -- -std=c99 $(XI_INCLUDE_FLAGS)
+
 $(XI_BIN_DIRS):
 	@mkdir -p $@
 ifdef XI_PROVIDE_RESOURCE_FILES

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,8 @@ endif
 static_analysis:  $(XI_SOURCES:.c=.sa)
 
 $(LIBXIVELY)/src/%.sa:
-	$(info clang-tidy --checks='clang-analyzer-*,-clang-analyzer-cplusplus*,-clang-analyzer-osx*' $(@:.sa=.c)) -- -std=c99 $(XI_INCLUDE_FLAGS)
+	$(info [clang-tidy] $(@:.sa=.c))
+	@clang-tidy --checks='clang-analyzer-*,-clang-analyzer-cplusplus*,-clang-analyzer-osx*' $(@:.sa=.c) >> static_analysis.log -- $(XI_CONFIG_FLAGS) $(XI_COMPILER_FLAGS) $(XI_INCLUDE_FLAGS)
 
 $(XI_BIN_DIRS):
 	@mkdir -p $@


### PR DESCRIPTION
[DESCRIPTION]
Added clang static analysis as a makefile target.

It was very easy to integrate the clang-tidy as a static analyser with our project. Now by calling ```make static_analysis``` we are able to get the ```static_analysis*.log``` in few seconds. We could try to integrate that with Travis as a next step.

[REVIEWERS]
@dellabitta

[QA]
Adds easy to use static analysis for our project. It works with ```clang-tidy```. 

[RELEASE NOTES]
Added clang static analysis as a makefile target.