### PR TITLE
Fix/senml va args argument promotion fix

### DIFF
--- a/include_senml/xively_senml.h
+++ b/include_senml/xively_senml.h
@@ -88,7 +88,7 @@ extern xi_state_t xi_senml_serialize( xi_senml_t* senml_structure,
  * @retval XI_STATE_OK if succeeded, other in case of failure,
  *         see xively_error.h for error codes
  */
-extern xi_state_t xi_create_senml_struct( xi_senml_t** senml_ptr, uint8_t count, ... );
+extern xi_state_t xi_create_senml_struct( xi_senml_t** senml_ptr, int count, ... );
 
 /**
  * @name xi_add_senml_entry
@@ -106,7 +106,7 @@ extern xi_state_t xi_create_senml_struct( xi_senml_t** senml_ptr, uint8_t count,
  * @retval XI_STATE_OK if succeeded, other in case of failure,
  *         see xively_error.h for error codes
  */
-extern xi_state_t xi_add_senml_entry( xi_senml_t* senml_ptr, uint8_t count, ... );
+extern xi_state_t xi_add_senml_entry( xi_senml_t* senml_ptr, int count, ... );
 
 /**
  * @name xi_senml_free_buffer

--- a/src/libxively/senml/xi_senml.c
+++ b/src/libxively/senml/xi_senml.c
@@ -101,10 +101,10 @@ void xi_senml_destroy( xi_senml_t** senml_structure )
     XI_SAFE_FREE( *senml_structure );
 }
 
-xi_state_t xi_create_senml_struct( xi_senml_t** senml_ptr, uint8_t count, ... )
+xi_state_t xi_create_senml_struct( xi_senml_t** senml_ptr, int count, ... )
 {
     xi_state_t state = XI_STATE_OK;
-
+ 
     XI_CHECK_CND( NULL == senml_ptr, XI_INVALID_PARAMETER, state );
     XI_CHECK_CND( NULL != *senml_ptr, XI_INVALID_PARAMETER, state );
 
@@ -204,7 +204,7 @@ void xi_debug_dump_senml_entry( const xi_senml_entry_t* entry, const char* prefi
     }
 }
 
-xi_state_t xi_add_senml_entry( xi_senml_t* senml_ptr, uint8_t count, ... )
+xi_state_t xi_add_senml_entry( xi_senml_t* senml_ptr, int count, ... )
 {
     xi_state_t state = XI_STATE_OK;
 


### PR DESCRIPTION
[DESCRIPTION]

Using clang-4.0 to compile our library I've noticed one warning about the promotion of types for the va_args arguments is undefined. This is the solution to that problem.
