### PR TITLE
example makefile changes for linux compatibility

### DIFF
--- a/examples/common/rules.mk
+++ b/examples/common/rules.mk
@@ -3,6 +3,8 @@
 # This is part of the Xively C Client library,
 # it is licensed under the BSD 3-Clause license.
 
+include ../../make/mt-config/mt-target-platform.mk
+
 CC ?= cc
 AR ?= ar
 
@@ -25,7 +27,12 @@ XI_EXAMPLE_BIN := $(XI_EXAMPLE_BINDIR)/$(XI_EXAMPLE_NAME)
 
 XI_CLIENT_PATH ?= $(CURDIR)/../../
 XI_CLIENT_INC_PATH ?= $(CURDIR)/../../include
-XI_CLIENT_LIB_PATH ?= $(CURDIR)/../../bin/osx
+
+ifeq ($(XI_HOST_PLATFORM),Linux)
+	XI_CLIENT_LIB_PATH ?= $(CURDIR)/../../bin/linux
+else ifeq ($(XI_HOST_PLATFORM),Darwin)
+	XI_CLIENT_LIB_PATH ?= $(CURDIR)/../../bin/osx
+endif
 
 XI_CLIENT_ROOTCA_LIST := $(CURDIR)/../../res/trusted_RootCA_certs/xi_RootCA_list.pem
 
@@ -46,4 +53,4 @@ endif
 
 # -lm is only needed by linux
 # -lpthread only if both linux and multithreading is enabled in the Xively C Client at compile time
-XI_FLAGS_LINKER := -L$(XI_CLIENT_LIB_PATH)  -lxively -lm -lpthread $(TLS_LIB_CONFIG_FLAGS)
+XI_FLAGS_LINKER := -L$(XI_CLIENT_LIB_PATH)  -lxively -lpthread $(TLS_LIB_CONFIG_FLAGS) -lm

--- a/examples/common/rules.mk
+++ b/examples/common/rules.mk
@@ -27,12 +27,7 @@ XI_EXAMPLE_BIN := $(XI_EXAMPLE_BINDIR)/$(XI_EXAMPLE_NAME)
 
 XI_CLIENT_PATH ?= $(CURDIR)/../../
 XI_CLIENT_INC_PATH ?= $(CURDIR)/../../include
-
-ifeq ($(XI_HOST_PLATFORM),Linux)
-	XI_CLIENT_LIB_PATH ?= $(CURDIR)/../../bin/linux
-else ifeq ($(XI_HOST_PLATFORM),Darwin)
-	XI_CLIENT_LIB_PATH ?= $(CURDIR)/../../bin/osx
-endif
+XI_CLIENT_LIB_PATH ?= $(CURDIR)/../../bin/$(XI_TARGET_PLATFORM)
 
 XI_CLIENT_ROOTCA_LIST := $(CURDIR)/../../res/trusted_RootCA_certs/xi_RootCA_list.pem
 

--- a/examples/common/rules.mk
+++ b/examples/common/rules.mk
@@ -48,4 +48,4 @@ endif
 
 # -lm is only needed by linux
 # -lpthread only if both linux and multithreading is enabled in the Xively C Client at compile time
-XI_FLAGS_LINKER := -L$(XI_CLIENT_LIB_PATH) $(TLS_LIB_CONFIG_FLAGS) -lxively -lpthread -lm
+XI_FLAGS_LINKER := -L$(XI_CLIENT_LIB_PATH)  -lxively -lpthread $(TLS_LIB_CONFIG_FLAGS) -lm

--- a/examples/common/rules.mk
+++ b/examples/common/rules.mk
@@ -48,4 +48,4 @@ endif
 
 # -lm is only needed by linux
 # -lpthread only if both linux and multithreading is enabled in the Xively C Client at compile time
-XI_FLAGS_LINKER := -L$(XI_CLIENT_LIB_PATH)  -lxively -lpthread $(TLS_LIB_CONFIG_FLAGS) -lm
+XI_FLAGS_LINKER := -L$(XI_CLIENT_LIB_PATH) $(TLS_LIB_CONFIG_FLAGS) -lxively -lpthread -lm


### PR DESCRIPTION
[DESCRIPTION]
Example makefile updates for Linux compatibility

[ JIRA ]
none

[REVIEWERS]
atigyi
@dellabitta

[QA]
libxively, wolfssl and examples compile and run on linux and on os x

[RELEASE NOTES]
Linux compatibility updates.