### PR TITLE
Feature/customer support build error cc3200

### DIFF
--- a/src/libxively/event_loop/xi_event_loop.c
+++ b/src/libxively/event_loop/xi_event_loop.c
@@ -4,6 +4,7 @@
  * it is licensed under the BSD 3-Clause license.
  */
 
+#include "xi_event_loop.h"
 #include "xi_bsp_io_net.h"
 #include "xi_bsp_time.h"
 #include "xi_event_dispatcher_api.h"

--- a/src/libxively/event_loop/xi_event_loop.h
+++ b/src/libxively/event_loop/xi_event_loop.h
@@ -13,9 +13,9 @@
 extern "C" {
 #endif
 
-void xi_event_loop_with_evtds( uint32_t num_iterations,
-                               xi_evtd_instance_t** event_dispatchers,
-                               uint8_t num_evtds );
+xi_state_t xi_event_loop_with_evtds( uint32_t num_iterations,
+                                     xi_evtd_instance_t** event_dispatchers,
+                                     uint8_t num_evtds );
 
 #ifdef __cplusplus
 }

--- a/src/libxively/io/fs/memory/xi_fs_memory.c
+++ b/src/libxively/io/fs/memory/xi_fs_memory.c
@@ -263,7 +263,7 @@ xi_state_t xi_fs_read( const void* context,
 
 xi_state_t xi_fs_write( const void* context,
                         const xi_fs_resource_handle_t resource_handle,
-                        const uint8_t* buffer,
+                        const uint8_t* const buffer,
                         const size_t buffer_size,
                         const size_t offset,
                         size_t* const bytes_written )


### PR DESCRIPTION
[DESCRIPTION]
Fixing a build error (xi_event_loop_with_evtds) for CC3200 occurring on TI's Code Composer Studio during linking the xively_demo example application with highes optimization level: -O4.

[REVIEWERS]

[JIRA]
customer support: fix -O4 build errors in CCS xively_demo project
https://jira.3amlabs.net/browse/XCL-2816

[QA]
First the build error was reproduced, then macOS cross-build to CC3200 + Travis builds succeeded.

[RELEASE NOTES]
Fixing a build error for CC3200 - xi_event_loop_with_evtds