### PR TITLE
Feature/build error cc3200 xi bsp io net select link error

### DIFF
--- a/include/bsp/xi_bsp_io_net.h
+++ b/include/bsp/xi_bsp_io_net.h
@@ -157,7 +157,7 @@ typedef intptr_t xi_bsp_socket_t;
 typedef struct xi_bsp_socket_events_s
 {
     /** platform specific value of socket */
-    xi_bsp_socket_t socket;
+    xi_bsp_socket_t xi_socket;
     /** 1 if socket wants to read 0 otherwise */
     uint8_t in_socket_want_read : 1;
     /** 1 if socket wants to write 0 otherwise */

--- a/src/bsp/platform/cc3200/xi_bsp_io_net_cc3200.c
+++ b/src/bsp/platform/cc3200/xi_bsp_io_net_cc3200.c
@@ -4,14 +4,9 @@
  * it is licensed under the BSD 3-Clause license.
  */
 
-#include <socket.h>
-/* note: socket.h has a define socket->sl_Socket,
-         this affects xi_bsp_socket_events_t->socket member.
-         This is the reason it is before xi_bsp_io_net.h.
-         Other solution is to rename the member, the former was chosen. */
-
 #include <xi_bsp_io_net.h>
 #include <stdio.h>
+#include <socket.h>
 
 #ifdef XI_BSP_IO_NET_TLS_SOCKET
 
@@ -269,24 +264,27 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
 
         if ( 1 == socket_events->in_socket_want_read )
         {
-            FD_SET( socket_events->socket, &rfds );
-            max_fd_read =
-                socket_events->socket > max_fd_read ? socket_events->socket : max_fd_read;
+            FD_SET( socket_events->xi_socket, &rfds );
+            max_fd_read = socket_events->xi_socket > max_fd_read
+                              ? socket_events->xi_socket
+                              : max_fd_read;
         }
 
         if ( ( 1 == socket_events->in_socket_want_write ) ||
              ( 1 == socket_events->in_socket_want_connect ) )
         {
-            FD_SET( socket_events->socket, &wfds );
-            max_fd_write = socket_events->socket > max_fd_write ? socket_events->socket
-                                                                : max_fd_write;
+            FD_SET( socket_events->xi_socket, &wfds );
+            max_fd_write = socket_events->xi_socket > max_fd_write
+                               ? socket_events->xi_socket
+                               : max_fd_write;
         }
 
         if ( 1 == socket_events->in_socket_want_error )
         {
-            FD_SET( socket_events->socket, &efds );
-            max_fd_error = socket_events->socket > max_fd_error ? socket_events->socket
-                                                                : max_fd_error;
+            FD_SET( socket_events->xi_socket, &efds );
+            max_fd_error = socket_events->xi_socket > max_fd_error
+                               ? socket_events->xi_socket
+                               : max_fd_error;
         }
     }
 
@@ -305,12 +303,12 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
         {
             xi_bsp_socket_events_t* socket_events = &socket_events_array[socket_id];
 
-            if ( FD_ISSET( socket_events->socket, &rfds ) )
+            if ( FD_ISSET( socket_events->xi_socket, &rfds ) )
             {
                 socket_events->out_socket_can_read = 1;
             }
 
-            if ( FD_ISSET( socket_events->socket, &wfds ) )
+            if ( FD_ISSET( socket_events->xi_socket, &wfds ) )
             {
                 if ( 1 == socket_events->in_socket_want_connect )
                 {
@@ -323,7 +321,7 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
                 }
             }
 
-            if ( FD_ISSET( socket_events->socket, &efds ) )
+            if ( FD_ISSET( socket_events->xi_socket, &efds ) )
             {
                 socket_events->out_socket_error = 1;
             }

--- a/src/bsp/platform/microchip_incomplete/xi_bsp_io_net_microchip.c
+++ b/src/bsp/platform/microchip_incomplete/xi_bsp_io_net_microchip.c
@@ -173,7 +173,7 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
 
         if ( 1 == socket_events->in_socket_want_connect )
         {
-            if ( TRUE == TCPIsConnected( socket_events->socket ) )
+            if ( TRUE == TCPIsConnected( socket_events->xi_socket ) )
             {
                 socket_events->out_socket_connect_finished = 1;
             }
@@ -181,16 +181,16 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
         }
 
         if ( 1 == socket_events->in_socket_want_read &&
-             ( TCPIsGetReady( socket_events->socket ) > 0 ||
-               0 == TCPIsConnected( socket_events->socket ) ) )
+             ( TCPIsGetReady( socket_events->xi_socket ) > 0 ||
+               0 == TCPIsConnected( socket_events->xi_socket ) ) )
         {
             socket_events->out_socket_can_read = 1;
             continue;
         }
 
         if ( 1 == socket_events->in_socket_want_write &&
-             ( TCPIsPutReady( socket_events->socket ) > 0 ||
-               0 == TCPIsConnected( socket_events->socket ) ) )
+             ( TCPIsPutReady( socket_events->xi_socket ) > 0 ||
+               0 == TCPIsConnected( socket_events->xi_socket ) ) )
         {
             socket_events->out_socket_can_write = 1;
             continue;

--- a/src/bsp/platform/posix/xi_bsp_io_net_posix.c
+++ b/src/bsp/platform/posix/xi_bsp_io_net_posix.c
@@ -230,24 +230,27 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
 
         if ( 1 == socket_events->in_socket_want_read )
         {
-            FD_SET( socket_events->socket, &rfds );
-            max_fd_read =
-                socket_events->socket > max_fd_read ? socket_events->socket : max_fd_read;
+            FD_SET( socket_events->xi_socket, &rfds );
+            max_fd_read = socket_events->xi_socket > max_fd_read
+                              ? socket_events->xi_socket
+                              : max_fd_read;
         }
 
         if ( ( 1 == socket_events->in_socket_want_write ) ||
              ( 1 == socket_events->in_socket_want_connect ) )
         {
-            FD_SET( socket_events->socket, &wfds );
-            max_fd_write = socket_events->socket > max_fd_write ? socket_events->socket
-                                                                : max_fd_write;
+            FD_SET( socket_events->xi_socket, &wfds );
+            max_fd_write = socket_events->xi_socket > max_fd_write
+                               ? socket_events->xi_socket
+                               : max_fd_write;
         }
 
         if ( 1 == socket_events->in_socket_want_error )
         {
-            FD_SET( socket_events->socket, &efds );
-            max_fd_error = socket_events->socket > max_fd_error ? socket_events->socket
-                                                                : max_fd_error;
+            FD_SET( socket_events->xi_socket, &efds );
+            max_fd_error = socket_events->xi_socket > max_fd_error
+                               ? socket_events->xi_socket
+                               : max_fd_error;
         }
     }
 
@@ -266,12 +269,12 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
         {
             xi_bsp_socket_events_t* socket_events = &socket_events_array[socket_id];
 
-            if ( FD_ISSET( socket_events->socket, &rfds ) )
+            if ( FD_ISSET( socket_events->xi_socket, &rfds ) )
             {
                 socket_events->out_socket_can_read = 1;
             }
 
-            if ( FD_ISSET( socket_events->socket, &wfds ) )
+            if ( FD_ISSET( socket_events->xi_socket, &wfds ) )
             {
                 if ( 1 == socket_events->in_socket_want_connect )
                 {
@@ -284,7 +287,7 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
                 }
             }
 
-            if ( FD_ISSET( socket_events->socket, &efds ) )
+            if ( FD_ISSET( socket_events->xi_socket, &efds ) )
             {
                 socket_events->out_socket_error = 1;
             }

--- a/src/bsp/platform/stm32f4/xi_bsp_io_net_stm32f4.c
+++ b/src/bsp/platform/stm32f4/xi_bsp_io_net_stm32f4.c
@@ -234,24 +234,27 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
 
         if ( 1 == socket_events->in_socket_want_read )
         {
-            FD_SET( socket_events->socket, &rfds );
-            max_fd_read =
-                socket_events->socket > max_fd_read ? socket_events->socket : max_fd_read;
+            FD_SET( socket_events->xi_socket, &rfds );
+            max_fd_read = socket_events->xi_socket > max_fd_read
+                              ? socket_events->xi_socket
+                              : max_fd_read;
         }
 
         if ( ( 1 == socket_events->in_socket_want_write ) ||
              ( 1 == socket_events->in_socket_want_connect ) )
         {
-            FD_SET( socket_events->socket, &wfds );
-            max_fd_write = socket_events->socket > max_fd_write ? socket_events->socket
-                                                                : max_fd_write;
+            FD_SET( socket_events->xi_socket, &wfds );
+            max_fd_write = socket_events->xi_socket > max_fd_write
+                               ? socket_events->xi_socket
+                               : max_fd_write;
         }
 
         if ( 1 == socket_events->in_socket_want_error )
         {
-            FD_SET( socket_events->socket, &efds );
-            max_fd_error = socket_events->socket > max_fd_error ? socket_events->socket
-                                                                : max_fd_error;
+            FD_SET( socket_events->xi_socket, &efds );
+            max_fd_error = socket_events->xi_socket > max_fd_error
+                               ? socket_events->xi_socket
+                               : max_fd_error;
         }
     }
 
@@ -270,12 +273,12 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
         {
             xi_bsp_socket_events_t* socket_events = &socket_events_array[socket_id];
 
-            if ( FD_ISSET( socket_events->socket, &rfds ) )
+            if ( FD_ISSET( socket_events->xi_socket, &rfds ) )
             {
                 socket_events->out_socket_can_read = 1;
             }
 
-            if ( FD_ISSET( socket_events->socket, &wfds ) )
+            if ( FD_ISSET( socket_events->xi_socket, &wfds ) )
             {
                 if ( 1 == socket_events->in_socket_want_connect )
                 {
@@ -288,7 +291,7 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
                 }
             }
 
-            if ( FD_ISSET( socket_events->socket, &efds ) )
+            if ( FD_ISSET( socket_events->xi_socket, &efds ) )
             {
                 socket_events->out_socket_error = 1;
             }

--- a/src/libxively/event_loop/xi_event_loop.c
+++ b/src/libxively/event_loop/xi_event_loop.c
@@ -100,7 +100,7 @@ xi_bsp_event_loop_transform_to_bsp_select( xi_evtd_instance_t** in_event_dispatc
             xi_bsp_socket_events_t* socket_to_update = &in_socket_events_array[socket_id];
             assert( NULL != socket_to_update );
 
-            socket_to_update->socket = tuple->fd;
+            socket_to_update->xi_socket = tuple->fd;
             socket_to_update->in_socket_want_read =
                 ( ( tuple->event_type & XI_EVENT_WANT_READ ) > 0 ) ? 1 : 0;
             socket_to_update->in_socket_want_write =
@@ -190,7 +190,7 @@ xi_bsp_event_loop_update_event_dispatcher( xi_evtd_instance_t** in_event_dispatc
             assert( NULL != socket_to_update );
 
             /* sanity check on socket id */
-            assert( tuple->fd == socket_to_update->socket );
+            assert( tuple->fd == socket_to_update->xi_socket );
 
             if ( 0 != socket_to_update->out_socket_can_read ||
                  0 != socket_to_update->out_socket_can_write ||
@@ -198,7 +198,7 @@ xi_bsp_event_loop_update_event_dispatcher( xi_evtd_instance_t** in_event_dispatc
                  0 != socket_to_update->out_socket_error )
             {
                 state = xi_evtd_update_event_on_socket( event_dispatcher,
-                                                        socket_to_update->socket );
+                                                        socket_to_update->xi_socket );
                 XI_CHECK_STATE( state );
             }
 


### PR DESCRIPTION
[DESCRIPTION]
Fixing a build error (xi_bsp_io_net_select) for CC3200 occurring on TI's Code Composer Studio during linking the xively_demo example application with highest optimization level: -O4.

[REVIEWERS]

[JIRA]
https://jira.3amlabs.net/browse/XCL-2817

[QA]
First the build error was reproduced, then macOS cross-build to CC3200 + Travis builds succeeded.

[RELEASE NOTES]
Fixing a build error for CC3200 - xi_bsp_io_net_select