### PR TITLE
Feature/nucleo wifi bsp io layer robustness

### DIFF
--- a/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_io_net_stm32f4_nucleo_wifi.c
+++ b/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_io_net_stm32f4_nucleo_wifi.c
@@ -5,7 +5,6 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <xi_bsp_io_net.h>
 #include <xi_data_desc.h>
 #include "wifi_interface.h"

--- a/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_io_net_stm32f4_nucleo_wifi.c
+++ b/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_io_net_stm32f4_nucleo_wifi.c
@@ -118,8 +118,8 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
         {
             xi_data_desc_t* head = xi_net_state.head;
 
-            size_t bytes_available = head->length - head->curr_pos;
-            size_t bytes_to_copy = bytes_available > count ? count : bytes_available;
+            const size_t bytes_available = head->length - head->curr_pos;
+            const size_t bytes_to_copy = ( bytes_available > count ) ? count : bytes_available;
 
             memcpy( buf, head->data_ptr + head->curr_pos , bytes_to_copy );
 

--- a/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_io_net_stm32f4_nucleo_wifi.c
+++ b/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_io_net_stm32f4_nucleo_wifi.c
@@ -110,7 +110,7 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
 
     if ( xi_net_state.wifi_state == xi_wifi_state_connected )
     {
-        if ( xi_net_state.head == NULL )
+        if ( NULL == xi_net_state.head )
         {
             return XI_BSP_IO_NET_STATE_BUSY;
         }
@@ -155,7 +155,7 @@ xi_bsp_io_net_state_t xi_bsp_io_net_close_socket( xi_bsp_socket_t* xi_socket )
     /* free all buffers */
 
     xi_data_desc_t* head = xi_net_state.head;
-    while ( head != NULL )
+    while ( NULL != head )
     {
         xi_data_desc_t* temp = head;
         head = head->__next;
@@ -188,7 +188,7 @@ xi_bsp_io_net_state_t xi_bsp_io_net_select( xi_bsp_socket_events_t* socket_event
 
             if ( 1 == socket_events->in_socket_want_read )
             {
-                if ( xi_net_state.head != NULL )
+                if ( NULL != xi_net_state.head )
                 {
                     socket_events->out_socket_can_read = 1;
                 }
@@ -223,11 +223,11 @@ void xi_bsp_io_net_socket_data_received_proxy( uint8_t socket_id,
 
     xi_data_desc_t* tail = xi_make_desc_from_buffer_copy( data_ptr , chunk_size );
 
-    if ( xi_net_state.head == NULL ) xi_net_state.head = tail;
+    if ( NULL == xi_net_state.head ) xi_net_state.head = tail;
     else
     {
         xi_data_desc_t* last = xi_net_state.head;
-        while ( last->__next != NULL ) last = last->__next;
+        while ( NULL != last->__next ) last = last->__next;
         last->__next = tail;
     }
 }

--- a/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_io_net_stm32f4_nucleo_wifi.c
+++ b/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_io_net_stm32f4_nucleo_wifi.c
@@ -18,8 +18,7 @@ extern "C" {
 #define MAX( a, b ) ( ( ( a ) > ( b ) ) ? ( a ) : ( b ) )
 #endif
 
-typedef enum 
-{
+typedef enum {
     xi_wifi_state_connected = 0,
     xi_wifi_state_disconnected,
     xi_wifi_state_error,
@@ -48,8 +47,8 @@ xi_bsp_io_net_connect( xi_bsp_socket_t* xi_socket, const char* host, uint16_t po
     char* protocol = "s"; // t -> tcp , s-> secure tcp, c-> secure tcp with certs
 
     WiFi_Status_t status = WiFi_MODULE_SUCCESS;
-    status = wifi_socket_client_open( ( uint8_t* )host, port,
-                                      ( uint8_t* )protocol, ( uint8_t* )xi_socket );
+    status = wifi_socket_client_open( ( uint8_t* )host, port, ( uint8_t* )protocol,
+                                      ( uint8_t* )xi_socket );
 
     if ( status == WiFi_MODULE_SUCCESS )
     {
@@ -119,19 +118,18 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
             xi_data_desc_t* head = xi_net_state.head;
 
             const size_t bytes_available = head->length - head->curr_pos;
-            const size_t bytes_to_copy = ( bytes_available > count ) ? count : bytes_available;
+            const size_t bytes_to_copy =
+                ( bytes_available > count ) ? count : bytes_available;
 
-            memcpy( buf, head->data_ptr + head->curr_pos , bytes_to_copy );
+            memcpy( buf, head->data_ptr + head->curr_pos, bytes_to_copy );
 
             head->curr_pos += bytes_to_copy;
             *out_read_count = bytes_to_copy;
 
-            if ( head->curr_pos == head->length ) 
+            if ( head->curr_pos == head->length )
             {
-                xi_data_desc_t* temp = head;
                 xi_net_state.head = head->__next;
-
-                xi_free_desc( &temp );
+                xi_free_desc( &head );
             }
         }
     }
@@ -158,7 +156,7 @@ xi_bsp_io_net_state_t xi_bsp_io_net_close_socket( xi_bsp_socket_t* xi_socket )
     while ( NULL != head )
     {
         xi_data_desc_t* temp = head;
-        head = head->__next;
+        head                 = head->__next;
         xi_free_desc( &temp );
     }
 
@@ -221,13 +219,19 @@ void xi_bsp_io_net_socket_data_received_proxy( uint8_t socket_id,
     ( void )socket_id;
     ( void )message_size;
 
-    xi_data_desc_t* tail = xi_make_desc_from_buffer_copy( data_ptr , chunk_size );
+    xi_data_desc_t* tail = xi_make_desc_from_buffer_copy( data_ptr, chunk_size );
 
-    if ( NULL == xi_net_state.head ) xi_net_state.head = tail;
+    if ( NULL == xi_net_state.head )
+    {
+        xi_net_state.head = tail;
+    }
     else
     {
         xi_data_desc_t* last = xi_net_state.head;
-        while ( NULL != last->__next ) last = last->__next;
+        while ( NULL != last->__next )
+        {
+            last = last->__next;
+        }
         last->__next = tail;
     }
 }


### PR DESCRIPTION
[DESCRIPTION]
- added a xi_data_desc_t based buffer chain to the io layer to store incoming data chunks

[ JIRA ]
https://jira.3amlabs.net/browse/XCL-2851

[REVIEWERS]

[QA]
travis tests pass
tested with 1600 byte length packets from the CPM web mqtt client

[RELEASE NOTES]
STM32F4 Nucleo BSP robustness improvements