### PR TITLE
Feature/stm32fx nucleo wifi rng bsp

### DIFF
--- a/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_rng_stm32f4_nucleo_wifi.c
+++ b/src/bsp/platform/stm32f4_nucleo_wifi/xi_bsp_rng_stm32f4_nucleo_wifi.c
@@ -5,17 +5,20 @@
  */
 
 #include <xi_bsp_rng.h>
+#include <stdlib.h>
+#include <xi_bsp_time.h>
 
 void xi_bsp_rng_init()
-{ /* check if already initialized */
+{
+    srand( xi_bsp_time_getcurrenttime_seconds() );
 }
 
 uint32_t xi_bsp_rng_get()
 {
-    uint32_t random = 0;
-    return random;
+    return rand();
 }
 
 void xi_bsp_rng_shutdown()
 {
+    /* nothing to do here */
 }


### PR DESCRIPTION
[ Description ]
GNU random is used on the Nucleo F401RE since it does not support HAL RNG.

[ JIRA ]
Implement STM32F4 Nucleo Wifi BSP module RNG
https://jira.3amlabs.net/browse/XCL-2848

[ Reviewer ]

[ QA ]
Printed out series of generated random numbers, plotted it, haven't recognized eye-o-scopic pattern. Although the seed is constant since the xi_bsp_time_get returns 0 for now. As soon as the BSP TIME gets implemented a recheck on different series should be done.

[ Release Notes ]
n/a