### PR TITLE
Release/v1.2.5

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,12 @@
+# Xively Client version 1.2.5
+#### March 14 2017
+
+## Features
+
+- STM32F401RE Nucleo board + wifi X-NUCLEO-IDW01M1 expansion board support. Example Eclipse project and Tutorial (https://developer.xively.com/docs/stm32f4xx-nucleo) included. TLS connection to Xively Servers uses the wifi expansion on-board TLS solution. Accurate time initialised from SNTP servers.
+
+
+
 # Xively Client version 1.2.4
 #### Jan 17 2017
 

--- a/src/libxively/xi_version.h
+++ b/src/libxively/xi_version.h
@@ -9,6 +9,6 @@
 
 #define XI_MAJOR 1
 #define XI_MINOR 2
-#define XI_REVISION 4
+#define XI_REVISION 5
 
 #endif /* __XI_VERSION_H__ */


### PR DESCRIPTION
Relese v1.2.5

- STM32F401RE Nucleo board + wifi X-NUCLEO-IDW01M1 expansion board support. 
- Example Eclipse project and Tutorial (https://developer.xively.com/docs/stm32f4xx-nucleo) included. 
- TLS connection to Xively Servers uses the wifi expansion on-board TLS solution. 
- Accurate time initialised from SNTP servers.
