### PR TITLE
CC3220SF: Add xi_bsp_hton.h and fix call to xi_initialize() in the example

### DIFF
--- a/examples/cc3220sf/xively_demo/simplelinkWifi/provisioning_task.c
+++ b/examples/cc3220sf/xively_demo/simplelinkWifi/provisioning_task.c
@@ -755,8 +755,9 @@ ConfigureSimpleLinkToDefaultState()
     g_SecParams.Key = (signed char*) gApplicationControlBlock.desiredWifiKey;
     g_SecParams.KeyLen = strlen( (const char*) gApplicationControlBlock.desiredWifiKey );
     g_SecParams.Type = gApplicationControlBlock.desiredWifiSecurityType;
-    ret = sl_WlanProfileAdd( (const signed char *) gApplicationControlBlock.desiredWifiSSID
-    						, strlen(gApplicationControlBlock.desiredWifiSSID), 0, &g_SecParams, 0, 1, 0 );
+    ret = sl_WlanProfileAdd(
+        ( const signed char* )gApplicationControlBlock.desiredWifiSSID,
+        strlen( gApplicationControlBlock.desiredWifiSSID ), 0, &g_SecParams, 0, 1, 0 );
     ASSERT_ON_ERROR(ret);
 
     /* Set connection policy to Auto (no AutoProvisioning)  */
@@ -1176,10 +1177,10 @@ static _i32 validateLocalLinkConnection(SlWlanMode_e *deviceRole)
 	*deviceRole = ROLE_STA;
 
 	SlWlanSecParams_t g_SecParams;
-    g_SecParams.Key = (char*)gApplicationControlBlock.desiredWifiKey;
+    g_SecParams.Key = (signed char*)gApplicationControlBlock.desiredWifiKey;
     g_SecParams.KeyLen = strlen( (const char*) g_SecParams.Key );
     g_SecParams.Type = gApplicationControlBlock.desiredWifiSecurityType;
-    sl_WlanProfileAdd( (char*)gApplicationControlBlock.desiredWifiSSID,
+    sl_WlanProfileAdd( (const signed char*)gApplicationControlBlock.desiredWifiSSID,
     				   strlen(gApplicationControlBlock.desiredWifiSSID),
 					   0, &g_SecParams, 0, 1, 0 );
 

--- a/examples/cc3220sf/xively_demo/xively_example.c
+++ b/examples/cc3220sf/xively_demo/xively_example.c
@@ -47,6 +47,8 @@
 #include <simplelinkWifi/provisioning_task.h>
 
 #include "xively.h"
+#include "xi_bsp_rng.h"
+#include "xi_bsp_time.h"
 #include "config_file.h"
 
 #ifdef DEBUG_WOLFSSL
@@ -311,10 +313,10 @@ void* xivelyExampleThread( void* arg )
     /* Add Interrupt Callbacks for the board's two side buttons */
     /* the application will use these interrupts to publish events */
     /* to the xively service on the corresponding button topic */
-    GPIO_setCallback( Board_BUTTON0, button_interrupt_handler );
+    GPIO_setCallback( Board_BUTTON0, ( GPIO_CallbackFxn )button_interrupt_handler );
     GPIO_enableInt( Board_BUTTON0 );
 
-    GPIO_setCallback( Board_BUTTON1, button_interrupt_handler );
+    GPIO_setCallback( Board_BUTTON1, ( GPIO_CallbackFxn )button_interrupt_handler );
     GPIO_enableInt( Board_BUTTON1 );
 
     /* create a periodic Clock for updating LED button states depending on

--- a/examples/cc3220sf/xively_demo/xively_example.c
+++ b/examples/cc3220sf/xively_demo/xively_example.c
@@ -429,11 +429,11 @@ void ConnectToXively()
 {
     Report( "\t- Xively Account ID: %s\n", gApplicationControlBlock.xivelyAccountId );
     Report( "\t- Xively Device ID: %s\n", gApplicationControlBlock.xivelyDeviceId );
-    Report( "\t- Xively Device Pwd: %s\n",
-            gApplicationControlBlock.xivelyDevicePassword );
-    // Report( "\t- Xively Device Password: <secret>\n" );
+    Report( "\t- Xively Device Password: <secret>\n" );
+    // Report( "\t- Xively Device Pwd: %s\n",
+    //        gApplicationControlBlock.xivelyDevicePassword );
     xi_state_t ret_state = xi_initialize( gApplicationControlBlock.xivelyAccountId,
-                                          gApplicationControlBlock.xivelyDeviceId, 0 );
+                                          gApplicationControlBlock.xivelyDeviceId );
 
     if ( XI_STATE_OK != ret_state )
     {

--- a/src/bsp/platform/cc3220sf/xi_bsp_hton.h
+++ b/src/bsp/platform/cc3220sf/xi_bsp_hton.h
@@ -1,0 +1,2 @@
+#include <socket.h>
+typedef long int ssize_t;


### PR DESCRIPTION
[ Description ]

- Remove outdated parameter from the xi_initialize() function call in cc3220sf example
- Add `xi_bsp_hton.h` header to cc3220sf BSP -> Fixes `fatal error #1965: cannot open source file "xi_bsp_hton.h"` during libxively.a compilation
- Fix multiple harmless application build warnings

[ JIRA ]
None.

[ Reviewer ]
@DellaBitta

[ QA ]
- libxively.a compiles for CC3220SF and CC3220SF_TLS_SOCKET presets
- Application compiles for all build configurations

[ Release Notes ]