### PR TITLE
FWU example build fix: adding back xi_bsp_crypt.h file

### DIFF
--- a/include/bsp/xi_bsp_crypt.h
+++ b/include/bsp/xi_bsp_crypt.h
@@ -1,0 +1,16 @@
+/* Copyright (c) 2003-2017, LogMeIn, Inc. All rights reserved.
+ *
+ * This is part of the Xively C Client library,
+ * it is licensed under the BSD 3-Clause license.
+ */
+
+#ifndef __XI_BSP_CRYPT_H__
+#define __XI_BSP_CRYPT_H__
+
+#include <stdint.h>
+
+void xi_bsp_crypt_sha256_init( void** );
+void xi_bsp_crypt_sha256_update( void*, const uint8_t*, uint32_t );
+void xi_bsp_crypt_sha256_final( void*, uint8_t* );
+
+#endif /* __XI_BSP_CRYPT_H__ */

--- a/src/tests/utests/xi_utest_sha256.c
+++ b/src/tests/utests/xi_utest_sha256.c
@@ -8,15 +8,12 @@
 #include "tinytest_macros.h"
 #include "xi_tt_testcase_management.h"
 #include "xi_utest_basic_testcase_frame.h"
+#include "xi_bsp_crypt.h"
 
 #include <stdio.h>
 #include <time.h>
 #include <stdint.h>
 #include <string.h>
-
-void xi_bsp_crypt_sha256_init( void** );
-void xi_bsp_crypt_sha256_update( void*, const uint8_t*, uint32_t );
-void xi_bsp_crypt_sha256_final( void*, uint8_t* );
 
 #ifndef XI_TT_TESTCASE_ENUMERATION__SECONDPREPROCESSORRUN
 


### PR DESCRIPTION
[ Description ]
Fixing build issues with Firmware Update Examples both for CC3200 and osx. The file xi_bsp_crypt.h was accidentally removed with a previous PR.

[ JIRA ]

[ Reviewer ]

[ QA ]
Now both FWU example projects build successfully.

[ Release Notes ]
n/a
