### PR TITLE
FWU removed BSP state return values

### DIFF
--- a/include/bsp/xi_bsp_fwu.h
+++ b/include/bsp/xi_bsp_fwu.h
@@ -14,15 +14,35 @@
 extern "C" {
 #endif
 
+/**
+ * @typedef xi_bsp_io_fwu_state_e
+ * @brief Return value of the BSP NET API functions.
+ *
+ * The implementation reports internal status to Xively Client through these values.
+ */
+ typedef enum xi_bsp_io_fwu_state_e {
+    /** operation finished successfully */
+    XI_BSP_IO_FWU_STATE_OK = 0,
+    /** operation failed on generic error */
+    XI_BSP_IO_FWU_ERROR = 1,
+    /** operation encountered and unexpected state or control path */
+    XI_BSP_IO_FWU_INTERNAL_ERROR = 2,
+    /** operation is not supported or not implemented */
+    XI_BSP_IO_FWU_NOT_IMPLEMENTED = 3,
+    /** parameter provided to BSP is invalid */
+    XI_BSP_IO_FWU_INVALID_PARAMETER = 4,
+} xi_bsp_io_fwu_state_t;
+
+
 uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name );
 
-xi_state_t xi_bsp_fwu_on_new_firmware_ok();
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok();
 
-xi_state_t xi_bsp_fwu_on_new_firmware_failure();
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_failure();
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_failure();
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_failure();
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name );
 
 

--- a/include/bsp/xi_bsp_fwu.h
+++ b/include/bsp/xi_bsp_fwu.h
@@ -14,37 +14,16 @@
 extern "C" {
 #endif
 
-/**
- * @typedef xi_bsp_io_fwu_state_e
- * @brief Return value of the BSP NET API functions.
- *
- * The implementation reports internal status to Xively Client through these values.
- */
- typedef enum xi_bsp_io_fwu_state_e {
-    /** operation finished successfully */
-    XI_BSP_IO_FWU_STATE_OK = 0,
-    /** operation failed on generic error */
-    XI_BSP_IO_FWU_ERROR = 1,
-    /** operation encountered and unexpected state or control path */
-    XI_BSP_IO_FWU_INTERNAL_ERROR = 2,
-    /** operation is not supported or not implemented */
-    XI_BSP_IO_FWU_NOT_IMPLEMENTED = 3,
-    /** parameter provided to BSP is invalid */
-    XI_BSP_IO_FWU_INVALID_PARAMETER = 4,
-} xi_bsp_io_fwu_state_t;
-
-
 uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name );
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok();
+void xi_bsp_fwu_on_new_firmware_ok();
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_failure();
+void xi_bsp_fwu_on_new_firmware_failure();
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_failure();
+void xi_bsp_fwu_on_firmware_package_download_failure();
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+void xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name );
-
 
 void xi_bsp_fwu_checksum_init( void** checksum_context );
 

--- a/include/bsp/xi_bsp_io_fs.h
+++ b/include/bsp/xi_bsp_io_fs.h
@@ -37,7 +37,7 @@ typedef intptr_t xi_bsp_io_fs_resource_handle_t;
 #define xi_bsp_io_fs_init_resource_handle() XI_BSP_IO_FS_INVALID_RESOURCE_HANDLE
 
 /**
- * @typedef xi_bsp_io_net_state_e
+ * @typedef xi_bsp_io_fs_state_e
  * @brief Return value of the BSP NET API functions.
  *
  * The implementation reports internal status to Xively Client through these values.

--- a/src/bsp/platform/cc3200/xi_bsp_fwu_cc3200.c
+++ b/src/bsp/platform/cc3200/xi_bsp_fwu_cc3200.c
@@ -36,17 +36,17 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return ( 0 == strcmp( "firmware.bin", resource_name ) ) ? 1 : 0;
 }
 
-xi_state_t xi_bsp_fwu_on_new_firmware_ok()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
 {
     if ( sl_extlib_FlcIsPendingCommit() )
     {
         sl_extlib_FlcCommit( FLC_COMMITED );
     }
 
-    return XI_STATE_OK;
+    return XI_BSP_IO_FWU_STATE_OK;
 }
 
-xi_state_t xi_bsp_fwu_on_new_firmware_failure()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_failure()
 {
     if ( sl_extlib_FlcIsPendingCommit() )
     {
@@ -56,17 +56,17 @@ xi_state_t xi_bsp_fwu_on_new_firmware_failure()
     _reboot_device();
 
     /* Control should never reach this */
-    return XI_INTERNAL_ERROR;
+    return XI_BSP_IO_FWU_INTERNAL_ERROR;
 }
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_failure()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_failure()
 {
     GPIO_IF_LedOn( MCU_RED_LED_GPIO );
 
-    return XI_STATE_OK;
+    return XI_BSP_IO_FWU_STATE_OK;
 }
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name )
 {
     ( void )firmware_resource_name;
@@ -77,5 +77,5 @@ xi_state_t xi_bsp_fwu_on_firmware_package_download_finished(
     _reboot_device();
 
     /* Control should never reach this */
-    return XI_INTERNAL_ERROR;
+    return XI_BSP_IO_FWU_INTERNAL_ERROR;
 }

--- a/src/bsp/platform/cc3200/xi_bsp_fwu_cc3200.c
+++ b/src/bsp/platform/cc3200/xi_bsp_fwu_cc3200.c
@@ -36,17 +36,15 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return ( 0 == strcmp( "firmware.bin", resource_name ) ) ? 1 : 0;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
+void xi_bsp_fwu_on_new_firmware_ok()
 {
     if ( sl_extlib_FlcIsPendingCommit() )
     {
         sl_extlib_FlcCommit( FLC_COMMITED );
     }
-
-    return XI_BSP_IO_FWU_STATE_OK;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_failure()
+void xi_bsp_fwu_on_new_firmware_failure()
 {
     if ( sl_extlib_FlcIsPendingCommit() )
     {
@@ -54,19 +52,14 @@ xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_failure()
     }
 
     _reboot_device();
-
-    /* Control should never reach this */
-    return XI_BSP_IO_FWU_INTERNAL_ERROR;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_failure()
+void xi_bsp_fwu_on_firmware_package_download_failure()
 {
     GPIO_IF_LedOn( MCU_RED_LED_GPIO );
-
-    return XI_BSP_IO_FWU_STATE_OK;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+void xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name )
 {
     ( void )firmware_resource_name;
@@ -75,7 +68,4 @@ xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
 
     /* reboot the device */
     _reboot_device();
-
-    /* Control should never reach this */
-    return XI_BSP_IO_FWU_INTERNAL_ERROR;
 }

--- a/src/bsp/platform/cc3200/xi_bsp_io_fs_cc3200.c
+++ b/src/bsp/platform/cc3200/xi_bsp_io_fs_cc3200.c
@@ -238,6 +238,6 @@ xi_bsp_io_fs_state_t xi_bsp_io_fs_remove( const char* const resource_name )
         return XI_BSP_IO_FS_REMOVE_ERROR;
     }
 
-    return ( 0 == sl_FsDel( ( const _u8* )resource_name, NULL ) ) ? XI_STATE_OK
+    return ( 0 == sl_FsDel( ( const _u8* )resource_name, NULL ) ) ? XI_BSP_IO_FS_STATE_OK
                                                                   : XI_BSP_IO_FS_REMOVE_ERROR;
 }

--- a/src/bsp/platform/dummy/xi_bsp_fwu_dummy.c
+++ b/src/bsp/platform/dummy/xi_bsp_fwu_dummy.c
@@ -13,25 +13,25 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return 0;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
+void xi_bsp_fwu_on_new_firmware_ok()
 {
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
+    return;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_failure()
+void xi_bsp_fwu_on_new_firmware_failure()
 {
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
+    return;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_failure()
+void xi_bsp_fwu_on_firmware_package_download_failure()
 {
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
+    return;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+void xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name )
 {
     ( void )firmware_resource_name;
 
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
+    return;
 }

--- a/src/bsp/platform/dummy/xi_bsp_fwu_dummy.c
+++ b/src/bsp/platform/dummy/xi_bsp_fwu_dummy.c
@@ -13,25 +13,25 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return 0;
 }
 
-xi_state_t xi_bsp_fwu_on_new_firmware_ok()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
 {
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_state_t xi_bsp_fwu_on_new_firmware_failure()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_failure()
 {
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_failure()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_failure()
 {
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name )
 {
     ( void )firmware_resource_name;
 
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }

--- a/src/bsp/platform/posix/xi_bsp_fwu_posix.c
+++ b/src/bsp/platform/posix/xi_bsp_fwu_posix.c
@@ -26,25 +26,25 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return ( 0 == strcmp( "firmware.bin", resource_name ) ) ? 1 : 0;
 }
 
-xi_state_t xi_bsp_fwu_on_new_firmware_ok()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
 {
     printf( "--- %s, no operation\n", __FUNCTION__ );
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_state_t xi_bsp_fwu_on_new_firmware_failure()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_failure()
 {
     printf( "--- %s, \n", __FUNCTION__ );
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_failure()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_failure()
 {
     printf( "--- %s, \n", __FUNCTION__ );
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name )
 {
     printf( "--- %s, firmware name: %s\n", __FUNCTION__, firmware_resource_name );
@@ -78,5 +78,5 @@ xi_state_t xi_bsp_fwu_on_firmware_package_download_finished(
 #endif
 
     /* Control should never reach this */
-    return XI_STATE_OK;
+    return XI_BSP_IO_FWU_STATE_OK;
 }

--- a/src/bsp/platform/posix/xi_bsp_fwu_posix.c
+++ b/src/bsp/platform/posix/xi_bsp_fwu_posix.c
@@ -26,26 +26,23 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return ( 0 == strcmp( "firmware.bin", resource_name ) ) ? 1 : 0;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
+void xi_bsp_fwu_on_new_firmware_ok()
 {
     printf( "--- %s, no operation\n", __FUNCTION__ );
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_failure()
+void xi_bsp_fwu_on_new_firmware_failure()
 {
     printf( "--- %s, \n", __FUNCTION__ );
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_failure()
+void xi_bsp_fwu_on_firmware_package_download_failure()
 {
     printf( "--- %s, \n", __FUNCTION__ );
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
-    const char* const firmware_resource_name )
+void xi_bsp_fwu_on_firmware_package_download_finished(
+        const char* const firmware_resource_name )
 {
     printf( "--- %s, firmware name: %s\n", __FUNCTION__, firmware_resource_name );
 
@@ -78,5 +75,4 @@ xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
 #endif
 
     /* Control should never reach this */
-    return XI_BSP_IO_FWU_STATE_OK;
 }

--- a/src/bsp/platform/stm32fx/xi_bsp_fwu_stm32fx.c
+++ b/src/bsp/platform/stm32fx/xi_bsp_fwu_stm32fx.c
@@ -14,15 +14,15 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return ( 0 == strcmp( "firmware.bin", resource_name ) ) ? 1 : 0;
 }
 
-xi_state_t xi_bsp_fwu_on_new_firmware_ok()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
 {
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name )
 {
     ( void )firmware_resource_name;
 
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }

--- a/src/bsp/platform/stm32fx/xi_bsp_fwu_stm32fx.c
+++ b/src/bsp/platform/stm32fx/xi_bsp_fwu_stm32fx.c
@@ -14,15 +14,15 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return ( 0 == strcmp( "firmware.bin", resource_name ) ) ? 1 : 0;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
+void xi_bsp_fwu_on_new_firmware_ok()
 {
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
+    return;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+void xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name )
 {
     ( void )firmware_resource_name;
 
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
+    return;
 }

--- a/src/bsp/platform/stm32fx_nucleo_wifi/xi_bsp_fwu_stm32fx_nucleo_wifi.c
+++ b/src/bsp/platform/stm32fx_nucleo_wifi/xi_bsp_fwu_stm32fx_nucleo_wifi.c
@@ -14,15 +14,15 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return ( 0 == strcmp( "firmware.bin", resource_name ) ) ? 1 : 0;
 }
 
-xi_state_t xi_bsp_fwu_on_new_firmware_ok()
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
 {
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }
 
-xi_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name )
 {
     ( void )firmware_resource_name;
 
-    return XI_NOT_IMPLEMENTED;
+    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }

--- a/src/bsp/platform/stm32fx_nucleo_wifi/xi_bsp_fwu_stm32fx_nucleo_wifi.c
+++ b/src/bsp/platform/stm32fx_nucleo_wifi/xi_bsp_fwu_stm32fx_nucleo_wifi.c
@@ -14,15 +14,13 @@ uint8_t xi_bsp_fwu_is_this_firmware( const char* const resource_name )
     return ( 0 == strcmp( "firmware.bin", resource_name ) ) ? 1 : 0;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_new_firmware_ok()
+void xi_bsp_fwu_on_new_firmware_ok()
 {
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
+    return;
 }
 
-xi_bsp_io_fwu_state_t xi_bsp_fwu_on_firmware_package_download_finished(
+void xi_bsp_fwu_on_firmware_package_download_finished(
     const char* const firmware_resource_name )
 {
     ( void )firmware_resource_name;
-
-    return XI_BSP_IO_FWU_NOT_IMPLEMENTED;
 }

--- a/src/libxively/sft/xi_sft_logic.c
+++ b/src/libxively/sft/xi_sft_logic.c
@@ -18,6 +18,37 @@
 
 #include <xi_fs_bsp_to_xi_mapping.h>
 
+/* helper function that translates the errno errors to the xi_bsp_io_fs_state_t values */
+xi_state_t xi_fs_bsp_io_fwu_2_xi_state( xi_bsp_io_fwu_state_t bsp_state_value )
+{
+    xi_state_t ret = XI_STATE_OK;
+
+    switch ( bsp_state_value )
+    {
+        case XI_BSP_IO_FWU_STATE_OK:
+            ret = XI_STATE_OK;
+            break;
+        case XI_BSP_IO_FWU_ERROR:
+            ret = XI_FS_ERROR;
+            break;
+        case XI_BSP_IO_FWU_INTERNAL_ERROR:
+            ret = XI_INTERNAL_ERROR;
+            break;
+        case XI_BSP_IO_FWU_NOT_IMPLEMENTED:
+            ret = XI_NOT_IMPLEMENTED;
+            break;
+        case XI_BSP_IO_FWU_INVALID_PARAMETER:
+            ret = XI_INVALID_PARAMETER;
+            break;
+        default:
+            /** If we're good engineers, then this should never happen */
+            ret = XI_INTERNAL_ERROR;
+            break;
+    }
+
+    return ret;
+}
+
 xi_state_t xi_sft_make_context( xi_sft_context_t** context,
                                 const char** updateable_files,
                                 uint16_t updateable_files_count,
@@ -96,7 +127,7 @@ xi_state_t xi_sft_on_connection_failed( xi_sft_context_t* context )
 {
     XI_UNUSED( context );
 
-    return xi_bsp_fwu_on_new_firmware_failure();
+    return xi_fs_bsp_io_fwu_2_xi_state( xi_bsp_fwu_on_new_firmware_failure() );
 }
 
 static void

--- a/src/libxively/sft/xi_sft_logic.c
+++ b/src/libxively/sft/xi_sft_logic.c
@@ -18,37 +18,6 @@
 
 #include <xi_fs_bsp_to_xi_mapping.h>
 
-/* helper function that translates the errno errors to the xi_bsp_io_fs_state_t values */
-xi_state_t xi_fs_bsp_io_fwu_2_xi_state( xi_bsp_io_fwu_state_t bsp_state_value )
-{
-    xi_state_t ret = XI_STATE_OK;
-
-    switch ( bsp_state_value )
-    {
-        case XI_BSP_IO_FWU_STATE_OK:
-            ret = XI_STATE_OK;
-            break;
-        case XI_BSP_IO_FWU_ERROR:
-            ret = XI_FS_ERROR;
-            break;
-        case XI_BSP_IO_FWU_INTERNAL_ERROR:
-            ret = XI_INTERNAL_ERROR;
-            break;
-        case XI_BSP_IO_FWU_NOT_IMPLEMENTED:
-            ret = XI_NOT_IMPLEMENTED;
-            break;
-        case XI_BSP_IO_FWU_INVALID_PARAMETER:
-            ret = XI_INVALID_PARAMETER;
-            break;
-        default:
-            /** If we're good engineers, then this should never happen */
-            ret = XI_INTERNAL_ERROR;
-            break;
-    }
-
-    return ret;
-}
-
 xi_state_t xi_sft_make_context( xi_sft_context_t** context,
                                 const char** updateable_files,
                                 uint16_t updateable_files_count,
@@ -127,7 +96,9 @@ xi_state_t xi_sft_on_connection_failed( xi_sft_context_t* context )
 {
     XI_UNUSED( context );
 
-    return xi_fs_bsp_io_fwu_2_xi_state( xi_bsp_fwu_on_new_firmware_failure() );
+    xi_bsp_fwu_on_new_firmware_failure();
+    
+    return XI_STATE_OK;
 }
 
 static void


### PR DESCRIPTION
[ Description ]
XI_BSP_IO_FS Enumeration and Struct Type removed.

The invoking layer of these functions doesn't do any logical reaction to the return values, so we're removing them.

[ JIRA ]
XCL-3061 [ SFT ] Update FWU Enums and Types
https://jira.3amlabs.net/browse/XCL-3061

[ Reviewer ]

[ QA ]
Travis and Local Builds

[ Release Notes ]
n/a