### PR TITLE
Fix WolfSSL build for ESP32 platform

### DIFF
--- a/examples/esp32/xively_demo/wolfssl-make/Makefile
+++ b/examples/esp32/xively_demo/wolfssl-make/Makefile
@@ -82,7 +82,6 @@ WOLFSSL_SETTINGS =        \
     -DNO_SHA512           \
     -DNO_STDIO_FILESYSTEM \
     -DNO_WOLFSSL_DIR      \
-    -DNO_WOLFSSL_SERVER   \
     -DNO_DH               \
     -DWOLFSSL_STATIC_RSA  \
     -DWOLFSSL_IAR_ARM     \


### PR DESCRIPTION
[ Description ]
WolfSSL builds fine with the existing settings in macOS, Ubuntu and Windows 10, so I'm not sure why it's not working for other users.

@atigyi 's suggested solution of removing the NO_WOLFSSL_SERVER fixed the issue for other users, and I've validated it still works on my machine, so let's just push the fix and move to the next task.

[ JIRA ]

[ Reviewer ]

[ QA ]
Built the binaries on macOS, WilliamFrasson was able to solve his issue #153 with this fix.

[ Release Notes ]
Fix WolfSSL build for the ESP32 platform.