### PR TITLE
New Feature: xi_is_context_connected

### DIFF
--- a/examples/mqtt_logic_producer/src/mqtt_logic_producer.c
+++ b/examples/mqtt_logic_producer/src/mqtt_logic_producer.c
@@ -136,15 +136,12 @@ int xi_mqtt_logic_producer_main( xi_embedded_args_t* xi_embedded_args )
         to numerous topics.  If you would like to use more than one
         connection then please use xi_create_context to create more
         contexts. */
-    printf( "on_connection_state_changed pre create status: %d\n", xi_is_context_connected( xi_context ) );
     xi_context = xi_create_context();
     if ( XI_INVALID_CONTEXT_HANDLE >= xi_context )
     {
         printf( " xi failed to create context, error: %d\n", -xi_context );
         return -1;
     }
-    printf( "on_connection_state_changed post create status: %d\n", xi_is_context_connected( xi_context ) );
-
 
     /*  Create a connection request with the credentials.
         The topic name will be used for publication requests
@@ -158,9 +155,6 @@ int xi_mqtt_logic_producer_main( xi_embedded_args_t* xi_embedded_args )
 
     xi_connect( xi_context, xi_username, xi_password, connection_timeout,
                 keepalive_timeout, XI_SESSION_CLEAN, &on_connection_state_changed );
-
-    printf( "on_connection_state_changed post connect request status: %d\n", xi_is_context_connected( xi_context ) );
-
 
     /* The Xively Client was designed for single threaded devices. As such
         it does not have its own event loop thread. Instead you must regularly call
@@ -218,7 +212,6 @@ void on_connection_state_changed( xi_context_handle_t in_context_handle,
                                   void* data,
                                   xi_state_t state )
 {
-    printf( "on_connection_state_changed connection status: %d\n", xi_is_context_connected( in_context_handle ) );
     xi_connection_data_t* conn_data = ( xi_connection_data_t* )data;
 
     switch ( conn_data->connection_state )
@@ -314,8 +307,7 @@ void delayed_publish( xi_context_handle_t context_handle,
     XI_UNUSED( user_data );
 
     printf( "publishing msg\n" );
-    printf( "publish connection status: %d\n", xi_is_context_connected( context_handle ) );
-
+    
     /* sending the connect request */
     xi_publish( context_handle, xi_publishtopic, "Hello From Xively!", xi_example_qos,
                 XI_MQTT_RETAIN_FALSE, NULL, NULL );

--- a/examples/mqtt_logic_producer/src/mqtt_logic_producer.c
+++ b/examples/mqtt_logic_producer/src/mqtt_logic_producer.c
@@ -136,12 +136,14 @@ int xi_mqtt_logic_producer_main( xi_embedded_args_t* xi_embedded_args )
         to numerous topics.  If you would like to use more than one
         connection then please use xi_create_context to create more
         contexts. */
+    printf( "on_connection_state_changed pre create status: %d\n", xi_is_context_connected( xi_context ) );
     xi_context = xi_create_context();
     if ( XI_INVALID_CONTEXT_HANDLE >= xi_context )
     {
         printf( " xi failed to create context, error: %d\n", -xi_context );
         return -1;
     }
+    printf( "on_connection_state_changed post create status: %d\n", xi_is_context_connected( xi_context ) );
 
 
     /*  Create a connection request with the credentials.
@@ -156,6 +158,8 @@ int xi_mqtt_logic_producer_main( xi_embedded_args_t* xi_embedded_args )
 
     xi_connect( xi_context, xi_username, xi_password, connection_timeout,
                 keepalive_timeout, XI_SESSION_CLEAN, &on_connection_state_changed );
+
+    printf( "on_connection_state_changed post connect request status: %d\n", xi_is_context_connected( xi_context ) );
 
 
     /* The Xively Client was designed for single threaded devices. As such
@@ -214,6 +218,7 @@ void on_connection_state_changed( xi_context_handle_t in_context_handle,
                                   void* data,
                                   xi_state_t state )
 {
+    printf( "on_connection_state_changed connection status: %d\n", xi_is_context_connected( in_context_handle ) );
     xi_connection_data_t* conn_data = ( xi_connection_data_t* )data;
 
     switch ( conn_data->connection_state )
@@ -309,6 +314,7 @@ void delayed_publish( xi_context_handle_t context_handle,
     XI_UNUSED( user_data );
 
     printf( "publishing msg\n" );
+    printf( "publish connection status: %d\n", xi_is_context_connected( context_handle ) );
 
     /* sending the connect request */
     xi_publish( context_handle, xi_publishtopic, "Hello From Xively!", xi_example_qos,

--- a/include/xively.h
+++ b/include/xively.h
@@ -155,6 +155,23 @@ extern xi_state_t xi_delete_context( xi_context_handle_t context_handle );
 
 
 /**
+ * @brief     Used to determine the state of a xively context's connection to
+ * the Xively Service.
+ *
+ * @param [in] context handle to determine connection status of.
+ *
+ * @see xi_create_context
+ * @see xi_connect
+ * @see xi_connect_to
+ * 
+ * @retval 1 if the context is currently connected to the Xively Service
+ * @retval 0 if the context is invalid, or the connection is currently any
+ * of the other following states: Unitialized, connecting, closing or closed.
+ */
+ extern uint8_t xi_is_context_connected( xi_context_handle_t context_handle );
+
+
+/**
  * @brief     Invokes the Xively Event Processing loop.
  * @detailed  This function is meant when exectuing the Xively Client
  * as the main process and therefore it does not return until xi_events_stop

--- a/include/xively.h
+++ b/include/xively.h
@@ -156,7 +156,7 @@ extern xi_state_t xi_delete_context( xi_context_handle_t context_handle );
 
 /**
  * @brief     Used to determine the state of a xively context's connection to
- * the Xively Service.
+ * the remote service.
  *
  * @param [in] context handle to determine connection status of.
  *
@@ -164,7 +164,7 @@ extern xi_state_t xi_delete_context( xi_context_handle_t context_handle );
  * @see xi_connect
  * @see xi_connect_to
  * 
- * @retval 1 if the context is currently connected to the Xively Service
+ * @retval 1 if the context is currently connected
  * @retval 0 if the context is invalid, or the connection is currently any
  * of the other following states: Unitialized, connecting, closing or closed.
  */

--- a/src/libxively/xively.c
+++ b/src/libxively/xively.c
@@ -412,7 +412,6 @@ void xi_default_client_callback( xi_context_handle_t in_context_handle,
     XI_UNUSED( state );
 }
 
-
 xi_state_t xi_user_callback_wrapper( void* context,
                                      void* data,
                                      xi_state_t in_state,
@@ -432,6 +431,27 @@ err_handling:
     return state;
 }
 
+
+extern uint8_t xi_is_context_connected( xi_context_handle_t xih )
+{
+    if ( XI_INVALID_CONTEXT_HANDLE == xih ) 
+    {
+        return 0;
+    }
+
+    printf("getting object for handle\n" );
+    xi_context_t* xi =
+        ( xi_context_t* )xi_object_for_handle( xi_globals.context_handles_vector, xih );
+
+    printf("context: %p\n", xi );
+    
+    if( NULL == xi ||  NULL == xi->context_data.connection_data )
+    {
+        return 0;
+    }
+    
+    return xi->context_data.connection_data->connection_state == XI_CONNECTION_STATE_OPENED;
+}
 
 void xi_events_stop()
 {

--- a/src/libxively/xively.c
+++ b/src/libxively/xively.c
@@ -439,11 +439,8 @@ extern uint8_t xi_is_context_connected( xi_context_handle_t xih )
         return 0;
     }
 
-    printf("getting object for handle\n" );
     xi_context_t* xi =
         ( xi_context_t* )xi_object_for_handle( xi_globals.context_handles_vector, xih );
-
-    printf("context: %p\n", xi );
     
     if( NULL == xi ||  NULL == xi->context_data.connection_data )
     {

--- a/src/libxively/xively.c
+++ b/src/libxively/xively.c
@@ -447,8 +447,8 @@ extern uint8_t xi_is_context_connected( xi_context_handle_t xih )
         return 0;
     }
     
-    return xi->context_data.connection_data->connection_state == XI_CONNECTION_STATE_OPENED 
-            && xi->context_data.shutdown_state == XI_SHUTDOWN_UNINITIALISED;
+    return XI_CONNECTION_STATE_OPENED  == xi->context_data.connection_data->connection_state
+            && XI_SHUTDOWN_UNINITIALISED == xi->context_data.shutdown_state;
 }
 
 void xi_events_stop()

--- a/src/libxively/xively.c
+++ b/src/libxively/xively.c
@@ -441,13 +441,15 @@ extern uint8_t xi_is_context_connected( xi_context_handle_t xih )
 
     xi_context_t* xi =
         ( xi_context_t* )xi_object_for_handle( xi_globals.context_handles_vector, xih );
+
     
     if( NULL == xi ||  NULL == xi->context_data.connection_data )
     {
         return 0;
     }
     
-    return xi->context_data.connection_data->connection_state == XI_CONNECTION_STATE_OPENED;
+    return xi->context_data.connection_data->connection_state == XI_CONNECTION_STATE_OPENED 
+            && xi->context_data.shutdown_state == XI_SHUTDOWN_UNINITIALISED;
 }
 
 void xi_events_stop()

--- a/src/libxively/xively.c
+++ b/src/libxively/xively.c
@@ -431,7 +431,6 @@ err_handling:
     return state;
 }
 
-
 extern uint8_t xi_is_context_connected( xi_context_handle_t xih )
 {
     if ( XI_INVALID_CONTEXT_HANDLE == xih ) 

--- a/src/tests/itests/xi_itest_connect_error.c
+++ b/src/tests/itests/xi_itest_connect_error.c
@@ -314,6 +314,301 @@ void xi_itest_test_valid_flow__call_connect_function_twice__second_call_returns_
     }
 }
 
+void xi_itest_test_valid_flow__call_is_context_connected_on_connected_context__call_returns_true(
+    void** fixture_void )
+{
+    uint8_t evtd_loop_count_between_connect_calls = 0;
+    for ( ; evtd_loop_count_between_connect_calls < 10;
+          ++evtd_loop_count_between_connect_calls )
+    {
+        const xi_itest_connect_error__test_fixture_t* const fixture =
+            ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
+
+        XI_UNUSED( fixture );
+
+        xi_debug_format( "Number of evtd calls: %d",
+                         evtd_loop_count_between_connect_calls );
+
+        /* one call for mock broker layer chain init*/
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        /* no problem during CONNECT*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* CONNECT message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
+
+        /* CONNACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+
+
+#ifdef XI_CONTROL_TOPIC_ENABLED
+        /* second message (probably SUBSCRIBE on a control topic)*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* SUBSCRIBE message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
+
+        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
+                       fixture->control_topic_name );
+
+        /* SUBACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+#endif
+
+        /* DISCONNECT MESSAGE */
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
+                      XI_MQTT_TYPE_DISCONNECT );
+
+        /* SHUTDOWN */
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
+                      XI_STATE_OK );
+
+        xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+        xi_itest_connect_error__trigger_event_dispatcher(
+            fixture_void, evtd_loop_count_between_connect_calls );
+
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
+        
+        /* TEST IT */
+        int is_connected_result = xi_is_context_connected( xi_context_handle );
+               
+        expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
+                      XI_STATE_OK );
+
+        xi_itest_connect_error__trigger_shutdown( fixture_void );
+
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
+
+        /* artificially reset test case*/
+        xi_itest_connect_error_teardown( fixture_void );
+        xi_itest_connect_error_setup( fixture_void );
+
+        /* Evaluate result */
+        assert_int_equal( is_connected_result, 1 );
+    }
+}
+
+void xi_itest_test_valid_flow__call_is_context_connected_on_disconnecting_context__call_returns_false(
+    void** fixture_void )
+{
+    uint8_t evtd_loop_count_between_connect_calls = 0;
+    for ( ; evtd_loop_count_between_connect_calls < 10;
+          ++evtd_loop_count_between_connect_calls )
+    {
+        const xi_itest_connect_error__test_fixture_t* const fixture =
+            ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
+
+        XI_UNUSED( fixture );
+
+        xi_debug_format( "Number of evtd calls: %d",
+                         evtd_loop_count_between_connect_calls );
+
+        /* one call for mock broker layer chain init*/
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        /* no problem during CONNECT*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* CONNECT message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
+
+        /* CONNACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+
+
+#ifdef XI_CONTROL_TOPIC_ENABLED
+        /* second message (probably SUBSCRIBE on a control topic)*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* SUBSCRIBE message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
+
+        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
+                       fixture->control_topic_name );
+
+        /* SUBACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+#endif
+
+        /* DISCONNECT MESSAGE */
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
+                      XI_MQTT_TYPE_DISCONNECT );
+
+        /* SHUTDOWN */
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
+                      XI_STATE_OK );
+
+        xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+        xi_itest_connect_error__trigger_event_dispatcher(
+            fixture_void, evtd_loop_count_between_connect_calls );
+
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
+                
+        expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
+                      XI_STATE_OK );
+
+        xi_itest_connect_error__trigger_shutdown( fixture_void );
+
+        /* TEST IT */
+        int is_connected_result = xi_is_context_connected( xi_context_handle );  
+
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
+
+        /* artificially reset test case*/
+        xi_itest_connect_error_teardown( fixture_void );
+        xi_itest_connect_error_setup( fixture_void );
+
+        /* Evaluate result */
+        assert_int_equal( is_connected_result, 0 );
+    }
+}
+
+void xi_itest_test_valid_flow__call_is_context_connected_on_disconnected_context__call_returns_false(
+    void** fixture_void )
+{
+    uint8_t evtd_loop_count_between_connect_calls = 0;
+    for ( ; evtd_loop_count_between_connect_calls < 10;
+          ++evtd_loop_count_between_connect_calls )
+    {
+        const xi_itest_connect_error__test_fixture_t* const fixture =
+            ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
+
+        XI_UNUSED( fixture );
+
+        xi_debug_format( "Number of evtd calls: %d",
+                         evtd_loop_count_between_connect_calls );
+
+        /* one call for mock broker layer chain init*/
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        /* no problem during CONNECT*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* CONNECT message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
+
+        /* CONNACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+
+
+#ifdef XI_CONTROL_TOPIC_ENABLED
+        /* second message (probably SUBSCRIBE on a control topic)*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* SUBSCRIBE message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
+
+        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
+                       fixture->control_topic_name );
+
+        /* SUBACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+#endif
+
+        /* DISCONNECT MESSAGE */
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
+                      XI_MQTT_TYPE_DISCONNECT );
+
+        /* SHUTDOWN */
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
+                      XI_STATE_OK );
+
+        xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+        xi_itest_connect_error__trigger_event_dispatcher(
+            fixture_void, evtd_loop_count_between_connect_calls );
+
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
+                
+        expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
+                      XI_STATE_OK );
+
+        xi_itest_connect_error__trigger_shutdown( fixture_void );
+
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
+
+         /* TEST IT */
+         int is_connected_result = xi_is_context_connected( xi_context_handle );  
+
+        /* artificially reset test case*/
+        xi_itest_connect_error_teardown( fixture_void );
+        xi_itest_connect_error_setup( fixture_void );
+
+        /* Evaluate result */
+        assert_int_equal( is_connected_result, 0 );
+    }
+}
+
+
 void xi_itest_test_valid_flow__call_disconnect_twice_on_connected_context__second_call_should_return_error(
     void** fixture_void )
 {

--- a/src/tests/itests/xi_itest_connect_error.c
+++ b/src/tests/itests/xi_itest_connect_error.c
@@ -314,6 +314,215 @@ void xi_itest_test_valid_flow__call_connect_function_twice__second_call_returns_
     }
 }
 
+void xi_itest_test_valid_flow__call_disconnect_twice_on_connected_context__second_call_should_return_error(
+    void** fixture_void )
+{
+    uint8_t evtd_loop_count_between_connect_calls = 0;
+    for ( ; evtd_loop_count_between_connect_calls < 10;
+          ++evtd_loop_count_between_connect_calls )
+    {
+        xi_debug_printf( "gap = %d \n", evtd_loop_count_between_connect_calls );
+
+        const xi_itest_connect_error__test_fixture_t* const fixture =
+            ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
+
+        XI_UNUSED( fixture );
+
+        /* one call for mock broker layer chain init*/
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        /* no problem during CONNECT*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* CONNECT message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
+
+        /* CONNACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+
+
+#ifdef XI_CONTROL_TOPIC_ENABLED
+        /* second message (probably SUBSCRIBE on a control topic)*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* SUBSCRIBE message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
+
+        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
+                       fixture->control_topic_name );
+
+        /* SUBACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+#endif
+
+        /* DISCONNECT MESSAGE */
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
+                      XI_MQTT_TYPE_DISCONNECT );
+
+        /* SHUTDOWN */
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
+                      XI_STATE_OK );
+
+        xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
+
+        /* TRY TO CALL SHUTDOWN TWICE IN A ROW */
+        expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
+                      XI_STATE_OK );
+        xi_itest_connect_error__trigger_shutdown( fixture_void );
+
+        /* HERE GOES THE EVTD LOOPS */
+        xi_itest_connect_error__trigger_event_dispatcher(
+            fixture_void, evtd_loop_count_between_connect_calls );
+
+        expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
+                      evtd_loop_count_between_connect_calls == 0
+                          ? XI_ALREADY_INITIALIZED
+                          : XI_SOCKET_NO_ACTIVE_CONNECTION_ERROR );
+        xi_itest_connect_error__trigger_shutdown( fixture_void );
+
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
+
+        /* artificially reset test case*/
+        xi_itest_connect_error_teardown( fixture_void );
+        xi_itest_connect_error_setup( fixture_void );
+    }
+}
+
+void xi_itest_test_valid_flow__call_connect_function_then_disconnect_without_making_a_connection__shutdown_should_unregister_connect(
+    void** fixture_void )
+{
+    /* call initialisation and connect without dispatching any event */
+    xi_itest_connect_error__trigger_connect( fixture_void, 0 );
+
+    /* now we trigger shutdown immedietaly */
+    expect_value( xi_itest_connect_error__trigger_shutdown, local_state, XI_STATE_OK );
+    xi_itest_connect_error__trigger_shutdown( fixture_void );
+    xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 5 );
+}
+
+void xi_itest_test_valid_flow__call_is_context_connected_on_connecting_context__call_returns_false(
+    void** fixture_void )
+{
+    uint8_t evtd_loop_count_between_connect_calls = 0;
+    for ( ; evtd_loop_count_between_connect_calls < 10;
+          ++evtd_loop_count_between_connect_calls )
+    {
+        const xi_itest_connect_error__test_fixture_t* const fixture =
+            ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
+
+        XI_UNUSED( fixture );
+
+        xi_debug_format( "Number of evtd calls: %d",
+                         evtd_loop_count_between_connect_calls );
+
+        /* one call for mock broker layer chain init*/
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
+
+        /* no problem during CONNECT*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* CONNECT message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
+
+        /* CONNACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+
+
+#ifdef XI_CONTROL_TOPIC_ENABLED
+        /* second message (probably SUBSCRIBE on a control topic)*/
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+
+        /* SUBSCRIBE message arrives at mock broker*/
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
+
+        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
+                       fixture->control_topic_name );
+
+        /* SUBACK sent*/
+        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
+        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+#endif
+
+        /* DISCONNECT MESSAGE */
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
+        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
+                      XI_MQTT_TYPE_DISCONNECT );
+
+        /* SHUTDOWN */
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
+        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
+                      XI_STATE_OK );
+
+        xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+        
+        /* TEST IT */
+        int is_connected_result = xi_is_context_connected( xi_context_handle );  
+        
+        xi_itest_connect_error__trigger_event_dispatcher(
+            fixture_void, evtd_loop_count_between_connect_calls );
+
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
+                       
+        expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
+                      XI_STATE_OK );
+
+        xi_itest_connect_error__trigger_shutdown( fixture_void );
+
+        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
+
+        /* artificially reset test case*/
+        xi_itest_connect_error_teardown( fixture_void );
+        xi_itest_connect_error_setup( fixture_void );
+
+        /* Evaluate result */
+        assert_int_equal( is_connected_result, 0 );
+    }
+}
+
 void xi_itest_test_valid_flow__call_is_context_connected_on_connected_context__call_returns_true(
     void** fixture_void )
 {
@@ -596,8 +805,8 @@ void xi_itest_test_valid_flow__call_is_context_connected_on_disconnected_context
 
         xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
 
-         /* TEST IT */
-         int is_connected_result = xi_is_context_connected( xi_context_handle );  
+        /* TEST IT */
+        int is_connected_result = xi_is_context_connected( xi_context_handle );  
 
         /* artificially reset test case*/
         xi_itest_connect_error_teardown( fixture_void );
@@ -606,115 +815,4 @@ void xi_itest_test_valid_flow__call_is_context_connected_on_disconnected_context
         /* Evaluate result */
         assert_int_equal( is_connected_result, 0 );
     }
-}
-
-
-void xi_itest_test_valid_flow__call_disconnect_twice_on_connected_context__second_call_should_return_error(
-    void** fixture_void )
-{
-    uint8_t evtd_loop_count_between_connect_calls = 0;
-    for ( ; evtd_loop_count_between_connect_calls < 10;
-          ++evtd_loop_count_between_connect_calls )
-    {
-        xi_debug_printf( "gap = %d \n", evtd_loop_count_between_connect_calls );
-
-        const xi_itest_connect_error__test_fixture_t* const fixture =
-            ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
-
-        XI_UNUSED( fixture );
-
-        /* one call for mock broker layer chain init*/
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        /* no problem during CONNECT*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* CONNECT message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
-
-        /* CONNACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-
-
-#ifdef XI_CONTROL_TOPIC_ENABLED
-        /* second message (probably SUBSCRIBE on a control topic)*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* SUBSCRIBE message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
-
-        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
-                       fixture->control_topic_name );
-
-        /* SUBACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-#endif
-
-        /* DISCONNECT MESSAGE */
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
-                      XI_MQTT_TYPE_DISCONNECT );
-
-        /* SHUTDOWN */
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
-                      XI_STATE_OK );
-
-        xi_itest_connect_error__trigger_connect( fixture_void, 1 );
-        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
-
-        /* TRY TO CALL SHUTDOWN TWICE IN A ROW */
-        expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
-                      XI_STATE_OK );
-        xi_itest_connect_error__trigger_shutdown( fixture_void );
-
-        /* HERE GOES THE EVTD LOOPS */
-        xi_itest_connect_error__trigger_event_dispatcher(
-            fixture_void, evtd_loop_count_between_connect_calls );
-
-        expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
-                      evtd_loop_count_between_connect_calls == 0
-                          ? XI_ALREADY_INITIALIZED
-                          : XI_SOCKET_NO_ACTIVE_CONNECTION_ERROR );
-        xi_itest_connect_error__trigger_shutdown( fixture_void );
-
-        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
-
-        /* artificially reset test case*/
-        xi_itest_connect_error_teardown( fixture_void );
-        xi_itest_connect_error_setup( fixture_void );
-    }
-}
-
-void xi_itest_test_valid_flow__call_connect_function_then_disconnect_without_making_a_connection__shutdown_should_unregister_connect(
-    void** fixture_void )
-{
-    /* call initialisation and connect without dispatching any event */
-    xi_itest_connect_error__trigger_connect( fixture_void, 0 );
-
-    /* now we trigger shutdown immedietaly */
-    expect_value( xi_itest_connect_error__trigger_shutdown, local_state, XI_STATE_OK );
-    xi_itest_connect_error__trigger_shutdown( fixture_void );
-    xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 5 );
 }

--- a/src/tests/itests/xi_itest_connect_error.c
+++ b/src/tests/itests/xi_itest_connect_error.c
@@ -427,189 +427,75 @@ void xi_itest_test_valid_flow__call_connect_function_then_disconnect_without_mak
 void xi_itest_test_valid_flow__call_is_context_connected_on_connecting_context__call_returns_false(
     void** fixture_void )
 {
+    will_return_always( xi_mock_broker_layer__check_expected__LAYER_LEVEL,
+        CONTROL_SKIP_CHECK_EXPECTED );
+    will_return_always( xi_mock_broker_layer__check_expected__MQTT_LEVEL,
+            CONTROL_SKIP_CHECK_EXPECTED );
+    will_return_always( xi_mock_layer_tls_prev__check_expected__LAYER_LEVEL,
+            CONTROL_SKIP_CHECK_EXPECTED );
+
     uint8_t evtd_loop_count_between_connect_calls = 0;
     for ( ; evtd_loop_count_between_connect_calls < 10;
-          ++evtd_loop_count_between_connect_calls )
+    ++evtd_loop_count_between_connect_calls )
     {
-        const xi_itest_connect_error__test_fixture_t* const fixture =
-            ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
-
-        XI_UNUSED( fixture );
-
-        xi_debug_format( "Number of evtd calls: %d",
-                         evtd_loop_count_between_connect_calls );
-
-        /* one call for mock broker layer chain init*/
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        /* no problem during CONNECT*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* CONNECT message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
-
-        /* CONNACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-
-
-#ifdef XI_CONTROL_TOPIC_ENABLED
-        /* second message (probably SUBSCRIBE on a control topic)*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* SUBSCRIBE message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
-
-        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
-                       fixture->control_topic_name );
-
-        /* SUBACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-#endif
-
-        /* DISCONNECT MESSAGE */
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
-                      XI_MQTT_TYPE_DISCONNECT );
-
-        /* SHUTDOWN */
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
-                      XI_STATE_OK );
-
-        xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+    const xi_itest_connect_error__test_fixture_t* const fixture =
+    ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
+    XI_UNUSED( fixture );
+    xi_debug_format( "Number of evtd calls: %d",
+            evtd_loop_count_between_connect_calls );
+    xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+    
+    /* TEST IT */
+    int is_connected_result = xi_is_context_connected( xi_context_handle );
         
-        /* TEST IT */
-        int is_connected_result = xi_is_context_connected( xi_context_handle );  
-        
-        xi_itest_connect_error__trigger_event_dispatcher(
-            fixture_void, evtd_loop_count_between_connect_calls );
+    xi_itest_connect_error__trigger_event_dispatcher(
+    fixture_void, evtd_loop_count_between_connect_calls );
+    xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
 
-        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
-                       
-        expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
-                      XI_STATE_OK );
+    expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
+        XI_STATE_OK );
+    xi_itest_connect_error__trigger_shutdown( fixture_void );
+    xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
+    
+    /* artificially reset test case*/
+    xi_itest_connect_error_teardown( fixture_void );
+    xi_itest_connect_error_setup( fixture_void );
 
-        xi_itest_connect_error__trigger_shutdown( fixture_void );
-
-        xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
-
-        /* artificially reset test case*/
-        xi_itest_connect_error_teardown( fixture_void );
-        xi_itest_connect_error_setup( fixture_void );
-
-        /* Evaluate result */
-        assert_int_equal( is_connected_result, 0 );
+    /* Evaluate result */
+    assert_int_equal( is_connected_result, 0 );
     }
 }
 
 void xi_itest_test_valid_flow__call_is_context_connected_on_connected_context__call_returns_true(
     void** fixture_void )
 {
+    will_return_always( xi_mock_broker_layer__check_expected__LAYER_LEVEL,
+                        CONTROL_SKIP_CHECK_EXPECTED );
+    will_return_always( xi_mock_broker_layer__check_expected__MQTT_LEVEL,
+                        CONTROL_SKIP_CHECK_EXPECTED );
+    will_return_always( xi_mock_layer_tls_prev__check_expected__LAYER_LEVEL,
+                        CONTROL_SKIP_CHECK_EXPECTED );
     uint8_t evtd_loop_count_between_connect_calls = 0;
     for ( ; evtd_loop_count_between_connect_calls < 10;
           ++evtd_loop_count_between_connect_calls )
     {
         const xi_itest_connect_error__test_fixture_t* const fixture =
             ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
-
         XI_UNUSED( fixture );
-
         xi_debug_format( "Number of evtd calls: %d",
                          evtd_loop_count_between_connect_calls );
-
-        /* one call for mock broker layer chain init*/
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        /* no problem during CONNECT*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* CONNECT message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
-
-        /* CONNACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-
-
-#ifdef XI_CONTROL_TOPIC_ENABLED
-        /* second message (probably SUBSCRIBE on a control topic)*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* SUBSCRIBE message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
-
-        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
-                       fixture->control_topic_name );
-
-        /* SUBACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-#endif
-
-        /* DISCONNECT MESSAGE */
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
-                      XI_MQTT_TYPE_DISCONNECT );
-
-        /* SHUTDOWN */
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
-                      XI_STATE_OK );
-
         xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+
         xi_itest_connect_error__trigger_event_dispatcher(
             fixture_void, evtd_loop_count_between_connect_calls );
-
         xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
-        
+
         /* TEST IT */
         int is_connected_result = xi_is_context_connected( xi_context_handle );
-               
+                
         expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
                       XI_STATE_OK );
-
         xi_itest_connect_error__trigger_shutdown( fixture_void );
-
         xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
 
         /* artificially reset test case*/
@@ -624,90 +510,34 @@ void xi_itest_test_valid_flow__call_is_context_connected_on_connected_context__c
 void xi_itest_test_valid_flow__call_is_context_connected_on_disconnecting_context__call_returns_false(
     void** fixture_void )
 {
+    will_return_always( xi_mock_broker_layer__check_expected__LAYER_LEVEL,
+                        CONTROL_SKIP_CHECK_EXPECTED );
+    will_return_always( xi_mock_broker_layer__check_expected__MQTT_LEVEL,
+                        CONTROL_SKIP_CHECK_EXPECTED );
+    will_return_always( xi_mock_layer_tls_prev__check_expected__LAYER_LEVEL,
+                        CONTROL_SKIP_CHECK_EXPECTED );
     uint8_t evtd_loop_count_between_connect_calls = 0;
     for ( ; evtd_loop_count_between_connect_calls < 10;
           ++evtd_loop_count_between_connect_calls )
     {
         const xi_itest_connect_error__test_fixture_t* const fixture =
             ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
-
         XI_UNUSED( fixture );
-
         xi_debug_format( "Number of evtd calls: %d",
                          evtd_loop_count_between_connect_calls );
-
-        /* one call for mock broker layer chain init*/
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        /* no problem during CONNECT*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* CONNECT message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
-
-        /* CONNACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-
-
-#ifdef XI_CONTROL_TOPIC_ENABLED
-        /* second message (probably SUBSCRIBE on a control topic)*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* SUBSCRIBE message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
-
-        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
-                       fixture->control_topic_name );
-
-        /* SUBACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-#endif
-
-        /* DISCONNECT MESSAGE */
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
-                      XI_MQTT_TYPE_DISCONNECT );
-
-        /* SHUTDOWN */
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
-                      XI_STATE_OK );
-
         xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+        
         xi_itest_connect_error__trigger_event_dispatcher(
             fixture_void, evtd_loop_count_between_connect_calls );
-
         xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
-                
+           
         expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
                       XI_STATE_OK );
-
         xi_itest_connect_error__trigger_shutdown( fixture_void );
 
         /* TEST IT */
-        int is_connected_result = xi_is_context_connected( xi_context_handle );  
-
+        int is_connected_result = xi_is_context_connected( xi_context_handle );
+        
         xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
 
         /* artificially reset test case*/
@@ -722,92 +552,35 @@ void xi_itest_test_valid_flow__call_is_context_connected_on_disconnecting_contex
 void xi_itest_test_valid_flow__call_is_context_connected_on_disconnected_context__call_returns_false(
     void** fixture_void )
 {
+    will_return_always( xi_mock_broker_layer__check_expected__LAYER_LEVEL,
+                        CONTROL_SKIP_CHECK_EXPECTED );
+    will_return_always( xi_mock_broker_layer__check_expected__MQTT_LEVEL,
+                        CONTROL_SKIP_CHECK_EXPECTED );
+    will_return_always( xi_mock_layer_tls_prev__check_expected__LAYER_LEVEL,
+                        CONTROL_SKIP_CHECK_EXPECTED );
     uint8_t evtd_loop_count_between_connect_calls = 0;
     for ( ; evtd_loop_count_between_connect_calls < 10;
           ++evtd_loop_count_between_connect_calls )
     {
         const xi_itest_connect_error__test_fixture_t* const fixture =
             ( xi_itest_connect_error__test_fixture_t* )*fixture_void;
-
         XI_UNUSED( fixture );
-
         xi_debug_format( "Number of evtd calls: %d",
                          evtd_loop_count_between_connect_calls );
-
-        /* one call for mock broker layer chain init*/
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_connect, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        expect_value( xi_mock_broker_layer_init, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_connect, in_out_state, XI_STATE_OK );
-
-        /* no problem during CONNECT*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* CONNECT message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_CONNECT );
-
-        /* CONNACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-
-
-#ifdef XI_CONTROL_TOPIC_ENABLED
-        /* second message (probably SUBSCRIBE on a control topic)*/
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-
-        /* SUBSCRIBE message arrives at mock broker*/
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type, XI_MQTT_TYPE_SUBSCRIBE );
-
-        expect_string( xi_mock_broker_layer_pull, subscribe_topic_name,
-                       fixture->control_topic_name );
-
-        /* SUBACK sent*/
-        expect_value( xi_mock_broker_secondary_layer_push, in_out_state, XI_STATE_OK );
-        will_return( xi_mock_broker_secondary_layer_push, CONTROL_CONTINUE );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-#endif
-
-        /* DISCONNECT MESSAGE */
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_push, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_push, in_out_state, XI_STATE_WRITTEN );
-        expect_value( xi_mock_broker_layer_pull, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_pull, recvd_msg_type,
-                      XI_MQTT_TYPE_DISCONNECT );
-
-        /* SHUTDOWN */
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_broker_layer_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close, in_out_state, XI_STATE_OK );
-        expect_value( xi_mock_layer_tls_prev_close_externally, in_out_state,
-                      XI_STATE_OK );
-
         xi_itest_connect_error__trigger_connect( fixture_void, 1 );
+        
         xi_itest_connect_error__trigger_event_dispatcher(
             fixture_void, evtd_loop_count_between_connect_calls );
-
         xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 6 );
-                
+           
         expect_value( xi_itest_connect_error__trigger_shutdown, local_state,
                       XI_STATE_OK );
-
-        xi_itest_connect_error__trigger_shutdown( fixture_void );
-
+        xi_itest_connect_error__trigger_shutdown( fixture_void );        
         xi_itest_connect_error__trigger_event_dispatcher( fixture_void, 10 );
 
         /* TEST IT */
-        int is_connected_result = xi_is_context_connected( xi_context_handle );  
-
+        int is_connected_result = xi_is_context_connected( xi_context_handle );
+                
         /* artificially reset test case*/
         xi_itest_connect_error_teardown( fixture_void );
         xi_itest_connect_error_setup( fixture_void );

--- a/src/tests/itests/xi_itest_connect_error.h
+++ b/src/tests/itests/xi_itest_connect_error.h
@@ -19,6 +19,9 @@ extern void
 xi_itest_test_valid_flow__call_connect_function_twice__second_call_returns_error(
     void** state );
 extern void
+xi_itest_test_valid_flow__call_is_context_connected_on_connecting_context__call_returns_false(
+    void** state );    
+extern void
 xi_itest_test_valid_flow__call_is_context_connected_on_connected_context__call_returns_true(
     void** state );
 extern void
@@ -46,6 +49,18 @@ struct CMUnitTest xi_itests_connect_error[] = {
         xi_itest_connect_error_setup,
         xi_itest_connect_error_teardown ),
     cmocka_unit_test_setup_teardown(
+        xi_itest_test_valid_flow__call_disconnect_twice_on_connected_context__second_call_should_return_error,
+        xi_itest_connect_error_setup,
+        xi_itest_connect_error_teardown ),
+    cmocka_unit_test_setup_teardown(
+        xi_itest_test_valid_flow__call_connect_function_then_disconnect_without_making_a_connection__shutdown_should_unregister_connect,
+        xi_itest_connect_error_setup,
+        xi_itest_connect_error_teardown ),
+    cmocka_unit_test_setup_teardown(
+        xi_itest_test_valid_flow__call_is_context_connected_on_connecting_context__call_returns_false,
+        xi_itest_connect_error_setup,
+        xi_itest_connect_error_teardown ),
+    cmocka_unit_test_setup_teardown(
         xi_itest_test_valid_flow__call_is_context_connected_on_connected_context__call_returns_true,
         xi_itest_connect_error_setup,
         xi_itest_connect_error_teardown ),
@@ -55,14 +70,6 @@ struct CMUnitTest xi_itests_connect_error[] = {
         xi_itest_connect_error_teardown ),
     cmocka_unit_test_setup_teardown(
         xi_itest_test_valid_flow__call_is_context_connected_on_disconnected_context__call_returns_false,
-        xi_itest_connect_error_setup,
-        xi_itest_connect_error_teardown ),
-    cmocka_unit_test_setup_teardown(
-        xi_itest_test_valid_flow__call_disconnect_twice_on_connected_context__second_call_should_return_error,
-        xi_itest_connect_error_setup,
-        xi_itest_connect_error_teardown ),
-    cmocka_unit_test_setup_teardown(
-        xi_itest_test_valid_flow__call_connect_function_then_disconnect_without_making_a_connection__shutdown_should_unregister_connect,
         xi_itest_connect_error_setup,
         xi_itest_connect_error_teardown ),
 };

--- a/src/tests/itests/xi_itest_connect_error.h
+++ b/src/tests/itests/xi_itest_connect_error.h
@@ -19,6 +19,15 @@ extern void
 xi_itest_test_valid_flow__call_connect_function_twice__second_call_returns_error(
     void** state );
 extern void
+xi_itest_test_valid_flow__call_is_context_connected_on_connected_context__call_returns_true(
+    void** state );
+extern void
+xi_itest_test_valid_flow__call_is_context_connected_on_disconnecting_context__call_returns_false(
+    void** state );
+extern void
+xi_itest_test_valid_flow__call_is_context_connected_on_disconnected_context__call_returns_false(
+    void** state );
+extern void
 xi_itest_test_valid_flow__call_disconnect_twice_on_connected_context__second_call_should_return_error(
     void** state );
 extern void
@@ -34,6 +43,18 @@ struct CMUnitTest xi_itests_connect_error[] = {
         xi_itest_connect_error_teardown ),
     cmocka_unit_test_setup_teardown(
         xi_itest_test_valid_flow__call_connect_function_twice__second_call_returns_error,
+        xi_itest_connect_error_setup,
+        xi_itest_connect_error_teardown ),
+    cmocka_unit_test_setup_teardown(
+        xi_itest_test_valid_flow__call_is_context_connected_on_connected_context__call_returns_true,
+        xi_itest_connect_error_setup,
+        xi_itest_connect_error_teardown ),
+    cmocka_unit_test_setup_teardown(
+        xi_itest_test_valid_flow__call_is_context_connected_on_disconnecting_context__call_returns_false,
+        xi_itest_connect_error_setup,
+        xi_itest_connect_error_teardown ),
+    cmocka_unit_test_setup_teardown(
+        xi_itest_test_valid_flow__call_is_context_connected_on_disconnected_context__call_returns_false,
         xi_itest_connect_error_setup,
         xi_itest_connect_error_teardown ),
     cmocka_unit_test_setup_teardown(

--- a/src/tests/utests/xi_utest_connect.c
+++ b/src/tests/utests/xi_utest_connect.c
@@ -254,6 +254,40 @@ XI_TT_TESTCASE_WITH_SETUP( test_connect_lastwill_to__valid_host,
                            end:;
                            } )
 
+XI_TT_TESTCASE_WITH_SETUP( test_INVALID_is_context_connected_context,
+                           xi_utest_setup_basic,
+                           xi_utest_teardown_basic,
+                           NULL,
+                           {
+                                uint8_t is_connected = 0;
+                        
+                                /* Call xi_is_context_connected before creating a context */
+                                xi_context_handle_t xi_invalid_context = -1;
+                        
+                                is_connected = xi_is_context_connected( xi_invalid_context );
+                        
+                                tt_assert( 0 == is_connected );
+                            end:;
+                            } )
+                        
+XI_TT_TESTCASE_WITH_SETUP( test_VALID_is_context_connected_context,
+                            xi_utest_setup_basic,
+                            xi_utest_teardown_basic,
+                            NULL, 
+                            {
+                                uint8_t is_connected = 0;
+                        
+                                /* Call xi_is_context_connected after creating a context */
+                                xi_context_handle_t xi_context = xi_create_context();
+                                tt_assert( XI_INVALID_CONTEXT_HANDLE < xi_context );
+ 
+                                is_connected = xi_is_context_connected( xi_context );
+                        
+                                tt_assert( 0 == is_connected );
+                                xi_delete_context( xi_context );
+                            end:;
+                            } )
+     
 XI_TT_TESTGROUP_END
 
 #ifndef XI_TT_TESTCASE_ENUMERATION__SECONDPREPROCESSORRUN


### PR DESCRIPTION
[ Description ]
Added a new function to the xively.h API that returns 1 when a given context is connected to an MQTT service, or 0 if it's not. This can be used for easier connection state tracking in FSM implementations.

[ JIRA ]
https://jira.3amlabs.net/browse/XCL-3025

[ Reviewer ]

[ QA ]
Tested by altering the mqtt_logic_producer example
Added unit tests.

[ Release Notes ]
Added xi_is_context_connected( xi_context_handle_t ) to the standard Xively API.