### PR TITLE
Feature/sft qa autotests

### DIFF
--- a/examples/cc3200/xively_firmware_updates/SFT/xi_sft_client.c
+++ b/examples/cc3200/xively_firmware_updates/SFT/xi_sft_client.c
@@ -1043,7 +1043,7 @@ void xi_parse_file_chunk( xi_context_handle_t in_context_handle,
 void verify_sha256( xi_context_handle_t in_context_handle )
 {
     /* Finalize SHA256 Digest */
-    xi_bsp_fwu_checksum_final( download_ctx.checksum_context,
+    xi_bsp_fwu_checksum_final( &download_ctx.checksum_context,
                                &download_ctx.file_local_computed_fingerprint,
                                &download_ctx.file_local_computed_fingerprint_len );
     printf( "Calculated hash = 0x" );

--- a/include/bsp/xi_bsp_fwu.h
+++ b/include/bsp/xi_bsp_fwu.h
@@ -137,7 +137,7 @@ void xi_bsp_fwu_checksum_update( void* checksum_context,
  * @param [out] buffer_out outgoing pointer on an array containing the checksum itself.
  * @param [out] buffer_len_out the number of bytes of the outgoing buffer
  */
-void xi_bsp_fwu_checksum_final( void* checksum_context,
+void xi_bsp_fwu_checksum_final( void** checksum_context,
                                 uint8_t** buffer_out,
                                 uint16_t* buffer_len_out );
 

--- a/make/mt-config/tests/mt-tests-unit.mk
+++ b/make/mt-config/tests/mt-tests-unit.mk
@@ -29,7 +29,7 @@ endif
 ifdef XI_SECURE_FILE_TRANSFER_ENABLED
     XI_UTEST_SOURCES += $(wildcard $(XI_TEST_DIR)/common/control_topic/*.c)
 else
-    XI_UTEST_EXCLUDED += xi_utest_cbor_codec_ct_decode.c xi_utest_cbor_codec_ct_encode.c xi_utest_control_message_sft.c
+    XI_UTEST_EXCLUDED += xi_utest_cbor_codec_ct_decode.c xi_utest_cbor_codec_ct_encode.c xi_utest_control_message_sft.c xi_utest_sft_logic.c
 endif
 
 XI_UTEST_EXCLUDED := $(addprefix $(XI_UTEST_SOURCE_DIR)/, $(XI_UTEST_EXCLUDED))

--- a/src/bsp/tls/crypto-algorithms/xi_bsp_fwu_checksum_cryptoalgs.c
+++ b/src/bsp/tls/crypto-algorithms/xi_bsp_fwu_checksum_cryptoalgs.c
@@ -32,6 +32,6 @@ void xi_bsp_fwu_checksum_final( void** sha_ctx,
     *buffer_out     = checksum_cryptoalgs_sha256;
     *buffer_len_out = sizeof( checksum_cryptoalgs_sha256 );
 
-    xi_bsp_mem_free( &sha_ctx );
+    xi_bsp_mem_free( *sha_ctx );
     *sha_ctx = NULL;
 }

--- a/src/bsp/tls/crypto-algorithms/xi_bsp_fwu_checksum_cryptoalgs.c
+++ b/src/bsp/tls/crypto-algorithms/xi_bsp_fwu_checksum_cryptoalgs.c
@@ -23,14 +23,15 @@ void xi_bsp_fwu_checksum_update( void* sha_ctx, const uint8_t* data, uint32_t le
     sha256_update( ( SHA256_CTX* )sha_ctx, data, len );
 }
 
-void xi_bsp_fwu_checksum_final( void* sha_ctx,
+void xi_bsp_fwu_checksum_final( void** sha_ctx,
                                 uint8_t** buffer_out,
                                 uint16_t* buffer_len_out )
 {
-    sha256_final( ( SHA256_CTX* )sha_ctx, checksum_cryptoalgs_sha256 );
+    sha256_final( ( SHA256_CTX* )*sha_ctx, checksum_cryptoalgs_sha256 );
 
     *buffer_out     = checksum_cryptoalgs_sha256;
     *buffer_len_out = sizeof( checksum_cryptoalgs_sha256 );
 
-    xi_bsp_mem_free( sha_ctx );
+    xi_bsp_mem_free( &sha_ctx );
+    *sha_ctx = NULL;
 }

--- a/src/bsp/tls/mbedtls/xi_bsp_fwu_checksum_mbedtls.c
+++ b/src/bsp/tls/mbedtls/xi_bsp_fwu_checksum_mbedtls.c
@@ -25,14 +25,15 @@ void xi_bsp_fwu_checksum_update( void* sha_ctx, const uint8_t* data, uint32_t le
     mbedtls_sha256_update( ( mbedtls_sha256_context* )sha_ctx, data, len );
 }
 
-void xi_bsp_fwu_checksum_final( void* sha_ctx,
+void xi_bsp_fwu_checksum_final( void** sha_ctx,
                                 uint8_t** buffer_out,
                                 uint16_t* buffer_len_out )
 {
-    mbedtls_sha256_finish( ( mbedtls_sha256_context* )sha_ctx, checksum_mbedtls_sha256 );
+    mbedtls_sha256_finish( ( mbedtls_sha256_context* )*sha_ctx, checksum_mbedtls_sha256 );
 
     *buffer_out     = checksum_mbedtls_sha256;
     *buffer_len_out = sizeof( checksum_mbedtls_sha256 );
 
-    xi_bsp_mem_free( sha_ctx );
+    xi_bsp_mem_free( *sha_ctx );
+    *sha_ctx = NULL;
 }

--- a/src/bsp/tls/wolfssl/xi_bsp_fwu_checksum_wolfssl.c
+++ b/src/bsp/tls/wolfssl/xi_bsp_fwu_checksum_wolfssl.c
@@ -23,14 +23,15 @@ void xi_bsp_fwu_checksum_update( void* sha_ctx, const uint8_t* data, uint32_t le
     wc_Sha256Update( ( Sha256* )sha_ctx, data, len );
 }
 
-void xi_bsp_fwu_checksum_final( void* sha_ctx,
+void xi_bsp_fwu_checksum_final( void** sha_ctx,
                                 uint8_t** buffer_out,
                                 uint16_t* buffer_len_out )
 {
-    wc_Sha256Final( ( Sha256* )sha_ctx, checksum_wolfssl_sha256 );
+    wc_Sha256Final( ( Sha256* )*sha_ctx, checksum_wolfssl_sha256 );
 
     *buffer_out     = checksum_wolfssl_sha256;
     *buffer_len_out = sizeof( checksum_wolfssl_sha256 );
 
-    xi_bsp_mem_free( sha_ctx );
+    xi_bsp_mem_free( *sha_ctx );
+    *sha_ctx = NULL;
 }

--- a/src/libxively/sft/xi_sft_logic.c
+++ b/src/libxively/sft/xi_sft_logic.c
@@ -60,6 +60,10 @@ xi_state_t xi_sft_free_context( xi_sft_context_t** context )
 {
     if ( NULL != context && NULL != *context )
     {
+        xi_sft_on_message_file_chunk_checksum_final( *context );
+
+        xi_bsp_io_fs_close( ( *context )->update_file_handle );
+
         xi_control_message_free( &( *context )->update_message_fua );
 
         XI_SAFE_FREE( *context );
@@ -88,10 +92,14 @@ xi_state_t xi_sft_on_connected( xi_sft_context_t* context )
         return XI_INVALID_PARAMETER;
     }
 
-    xi_control_message_t* message_file_info = xi_control_message_create_file_info(
-        context->updateable_files, context->updateable_files_count );
+    if ( NULL != context->fn_send_message )
+    {
+        xi_control_message_t* message_file_info = xi_control_message_create_file_info(
+            context->updateable_files, context->updateable_files_count );
 
-    ( *context->fn_send_message )( context->send_message_user_data, message_file_info );
+        ( *context->fn_send_message )( context->send_message_user_data,
+                                       message_file_info );
+    }
 
     return state;
 }

--- a/src/libxively/sft/xi_sft_logic.c
+++ b/src/libxively/sft/xi_sft_logic.c
@@ -116,13 +116,17 @@ xi_state_t xi_sft_on_connection_failed( xi_sft_context_t* context )
 static void
 xi_sft_send_file_get_chunk( xi_sft_context_t* context, uint32_t offset, uint32_t length )
 {
-    xi_control_message_t* message_file_get_chunk =
-        xi_control_message_create_file_get_chunk(
-            context->update_current_file->name, context->update_current_file->revision,
-            offset, XI_MIN( XI_SFT_FILE_CHUNK_SIZE, length ) );
+    if ( NULL != context->fn_send_message )
+    {
+        xi_control_message_t* message_file_get_chunk =
+            xi_control_message_create_file_get_chunk(
+                context->update_current_file->name,
+                context->update_current_file->revision, offset,
+                XI_MIN( XI_SFT_FILE_CHUNK_SIZE, length ) );
 
-    ( *context->fn_send_message )( context->send_message_user_data,
-                                   message_file_get_chunk );
+        ( *context->fn_send_message )( context->send_message_user_data,
+                                       message_file_get_chunk );
+    }
 }
 
 static void
@@ -131,12 +135,17 @@ xi_sft_send_file_status( const xi_sft_context_t* context,
                          xi_control_message__sft_file_status_phase_t phase,
                          xi_control_message__sft_file_status_code_t code )
 {
-    xi_control_message_t* message_file_status = xi_control_message_create_file_status(
-        file_desc_ext ? file_desc_ext->name : context->update_current_file->name,
-        file_desc_ext ? file_desc_ext->revision : context->update_current_file->revision,
-        phase, code );
+    if ( NULL != context->fn_send_message )
+    {
+        xi_control_message_t* message_file_status = xi_control_message_create_file_status(
+            file_desc_ext ? file_desc_ext->name : context->update_current_file->name,
+            file_desc_ext ? file_desc_ext->revision
+                          : context->update_current_file->revision,
+            phase, code );
 
-    ( *context->fn_send_message )( context->send_message_user_data, message_file_status );
+        ( *context->fn_send_message )( context->send_message_user_data,
+                                       message_file_status );
+    }
 }
 
 

--- a/src/libxively/sft/xi_sft_logic_file_chunk_handlers.c
+++ b/src/libxively/sft/xi_sft_logic_file_chunk_handlers.c
@@ -21,9 +21,9 @@ xi_sft_on_message_file_chunk_process_file_chunk( xi_sft_context_t* context,
     /* at first chunk open file */
     if ( 0 == sft_message_in->file_chunk.offset )
     {
-        state = xi_fs_bsp_io_fs_2_xi_state( xi_bsp_io_fs_open( sft_message_in->file_chunk.name,
-                                            context->update_current_file->size_in_bytes,
-                                            XI_BSP_IO_FS_OPEN_WRITE, &context->update_file_handle ) );
+        state = xi_fs_bsp_io_fs_2_xi_state( xi_bsp_io_fs_open(
+            sft_message_in->file_chunk.name, context->update_current_file->size_in_bytes,
+            XI_BSP_IO_FS_OPEN_WRITE, &context->update_file_handle ) );
 
         if ( XI_STATE_OK != state )
         {
@@ -41,7 +41,7 @@ xi_sft_on_message_file_chunk_process_file_chunk( xi_sft_context_t* context,
     /* write bytes through FILE BSP */
     size_t bytes_written = 0;
 
-    state = xi_fs_bsp_io_fs_2_xi_state( 
+    state = xi_fs_bsp_io_fs_2_xi_state(
         xi_bsp_io_fs_write( context->update_file_handle, sft_message_in->file_chunk.chunk,
                             sft_message_in->file_chunk.length,
                             sft_message_in->file_chunk.offset, &bytes_written ) );
@@ -61,10 +61,17 @@ xi_sft_on_message_file_chunk_process_file_chunk( xi_sft_context_t* context,
 xi_control_message__sft_file_status_code_t
 xi_sft_on_message_file_chunk_checksum_final( xi_sft_context_t* context )
 {
+    if ( NULL == context || NULL == context->update_current_file ||
+         NULL == context->checksum_context )
+    {
+        return XI_CONTROL_MESSAGE__SFT_FILE_STATUS_CODE_ERROR__FILE_CHECKSUM_MISMATCH;
+    }
+
     uint8_t* locally_calculated_fingerprint     = NULL;
     uint16_t locally_calculated_fingerprint_len = 0;
 
-    xi_bsp_fwu_checksum_final( context->checksum_context, &locally_calculated_fingerprint,
+    xi_bsp_fwu_checksum_final( &context->checksum_context,
+                               &locally_calculated_fingerprint,
                                &locally_calculated_fingerprint_len );
 
     /* integrity check based on checksum values */

--- a/src/tests/common/control_topic/xi_control_message_sft_generators.c
+++ b/src/tests/common/control_topic/xi_control_message_sft_generators.c
@@ -1,0 +1,86 @@
+/* Copyright (c) 2003-2017, LogMeIn, Inc. All rights reserved.
+ *
+ * This is part of the Xively C Client library,
+ * it is licensed under the BSD 3-Clause license.
+ */
+
+#include <xi_control_message_sft_generators.h>
+
+#include <stddef.h>
+#include <xively_error.h>
+#include <xi_macros.h>
+
+uint8_t* xi_control_message_sft_get_reproducible_randomlike_bytes( uint32_t offset,
+                                                                   uint32_t length )
+{
+    xi_state_t state = XI_STATE_OK;
+
+    XI_ALLOC_BUFFER( uint8_t, reproducible_randomlike_bytes, length, state );
+
+    uint8_t* it_byte = reproducible_randomlike_bytes;
+
+    uint32_t id_byte = offset;
+    for ( ; id_byte < offset + length; ++id_byte, ++it_byte )
+    {
+        /* the simpliest "random" bytes */
+        *it_byte = id_byte;
+    }
+
+    return reproducible_randomlike_bytes;
+
+err_handling:
+
+    XI_SAFE_FREE( reproducible_randomlike_bytes );
+
+    return NULL;
+}
+
+xi_control_message_t*
+xi_control_message_sft_generate_reply_FILE_CHUNK( xi_control_message_t* control_message )
+{
+    if ( NULL == control_message )
+    {
+        return NULL;
+    }
+
+    uint8_t* file_chunk_out_artificial = NULL;
+    xi_state_t state                   = XI_STATE_OK;
+
+    enum XI_MOCK_BROKER_SFT_FILE_CHUNK_STATUS
+    {
+        MOCK_BROKER_SFT_FILE_CHUNK__REQUEST_IS_CORRECT                       = 0,
+        MOCK_BROKER_SFT_FILE_CHUNK__END_OF_FILE_CHUNK_MIGHT_BE_SHORTER       = 1,
+        MOCK_BROKER_SFT_FILE_CHUNK__OFFSET_IS_GREATER_THAN_FILE_LENGTH       = 2,
+        MOCK_BROKER_SFT_FILE_CHUNK__REQUESTED_LENGTH_IS_GREATER_THAN_MAXIMUM = 3,
+        MOCK_BROKER_SFT_FILE_CHUNK__FILE_UNAVAILABLE                         = 4,
+    };
+
+    XI_ALLOC( xi_control_message_t, control_message_reply, state );
+
+    file_chunk_out_artificial = xi_control_message_sft_get_reproducible_randomlike_bytes(
+        control_message->file_get_chunk.offset, control_message->file_get_chunk.length );
+
+    control_message_reply->file_chunk = ( struct file_chunk_s ){
+        .common = {.msgtype = XI_CONTROL_MESSAGE_SC__SFT_FILE_CHUNK, .msgver = 1},
+        .name     = control_message->file_get_chunk.name,
+        .revision = control_message->file_get_chunk.revision,
+        .offset   = control_message->file_get_chunk.offset,
+        .length   = control_message->file_get_chunk.length,
+        .status   = MOCK_BROKER_SFT_FILE_CHUNK__REQUEST_IS_CORRECT,
+        .chunk    = file_chunk_out_artificial};
+
+
+    /* prevent deallocation of name and revision since these are reused in reply msg
+     */
+    control_message->file_get_chunk.name     = NULL;
+    control_message->file_get_chunk.revision = NULL;
+
+    return control_message_reply;
+
+err_handling:
+
+    xi_control_message_free( &control_message_reply );
+    XI_SAFE_FREE( file_chunk_out_artificial );
+
+    return NULL;
+}

--- a/src/tests/common/control_topic/xi_control_message_sft_generators.h
+++ b/src/tests/common/control_topic/xi_control_message_sft_generators.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2003-2017, LogMeIn, Inc. All rights reserved.
+ *
+ * This is part of the Xively C Client library,
+ * it is licensed under the BSD 3-Clause license.
+ */
+
+#ifndef __XI_CONTROL_MESSAGE_SFT_GENERATORS_H__
+#define __XI_CONTROL_MESSAGE_SFT_GENERATORS_H__
+
+#include <xi_control_message.h>
+
+uint8_t* xi_control_message_sft_get_reproducible_randomlike_bytes( uint32_t offset,
+                                                                   uint32_t length );
+
+xi_control_message_t*
+xi_control_message_sft_generate_reply_FILE_CHUNK( xi_control_message_t* control_message );
+
+#endif /* __XI_CONTROL_MESSAGE_SFT_GENERATORS_H__ */

--- a/src/tests/itests/tools/xi_itest_mock_broker_sft_logic.c
+++ b/src/tests/itests/tools/xi_itest_mock_broker_sft_logic.c
@@ -65,7 +65,7 @@ void xi_mock_broker_sft_logic_get_fingerprint( uint32_t size_in_bytes,
 
     uint8_t* checksum = NULL;
 
-    xi_bsp_fwu_checksum_final( checksum_context, &checksum, fingerprint_len_out );
+    xi_bsp_fwu_checksum_final( &checksum_context, &checksum, fingerprint_len_out );
 
     xi_state_t state = XI_STATE_OK;
 

--- a/src/tests/itests/tools/xi_itest_mock_broker_sft_logic.c
+++ b/src/tests/itests/tools/xi_itest_mock_broker_sft_logic.c
@@ -13,32 +13,10 @@
 #include "xi_helpers.h"
 #include <xi_bsp_fwu.h>
 
+#include <xi_control_message_sft_generators.h>
+
 #ifdef XI_SECURE_FILE_TRANSFER_ENABLED
 
-uint8_t* xi_mock_broker_sft_logic_get_reproducible_randomlike_bytes( uint32_t offset,
-                                                                     uint32_t length )
-{
-    xi_state_t state = XI_STATE_OK;
-
-    XI_ALLOC_BUFFER( uint8_t, reproducible_randomlike_bytes, length, state );
-
-    uint8_t* it_byte = reproducible_randomlike_bytes;
-
-    uint32_t id_byte = offset;
-    for ( ; id_byte < offset + length; ++id_byte, ++it_byte )
-    {
-        /* the simpliest "random" bytes */
-        *it_byte = id_byte;
-    }
-
-    return reproducible_randomlike_bytes;
-
-err_handling:
-
-    XI_SAFE_FREE( reproducible_randomlike_bytes );
-
-    return NULL;
-}
 
 void xi_mock_broker_sft_logic_get_fingerprint( uint32_t size_in_bytes,
                                                uint8_t** fingerprint_out,
@@ -54,7 +32,7 @@ void xi_mock_broker_sft_logic_get_fingerprint( uint32_t size_in_bytes,
     }
 
     uint8_t* artificial_file_content =
-        xi_mock_broker_sft_logic_get_reproducible_randomlike_bytes( 0, size_in_bytes );
+        xi_control_message_sft_get_reproducible_randomlike_bytes( 0, size_in_bytes );
 
     void* checksum_context = NULL;
 
@@ -162,58 +140,6 @@ xi_mock_broker_sft_logic_on_file_info( xi_control_message_t* control_message )
     return control_message_reply;
 }
 
-xi_control_message_t* xi_mock_broker_sft_logic_generate_reply_FILE_CHUNK(
-    xi_control_message_t* control_message )
-{
-    if ( NULL == control_message )
-    {
-        return NULL;
-    }
-
-    uint8_t* file_chunk_out_artificial = NULL;
-    xi_state_t state                   = XI_STATE_OK;
-
-    enum XI_MOCK_BROKER_SFT_FILE_CHUNK_STATUS
-    {
-        MOCK_BROKER_SFT_FILE_CHUNK__REQUEST_IS_CORRECT                       = 0,
-        MOCK_BROKER_SFT_FILE_CHUNK__END_OF_FILE_CHUNK_MIGHT_BE_SHORTER       = 1,
-        MOCK_BROKER_SFT_FILE_CHUNK__OFFSET_IS_GREATER_THAN_FILE_LENGTH       = 2,
-        MOCK_BROKER_SFT_FILE_CHUNK__REQUESTED_LENGTH_IS_GREATER_THAN_MAXIMUM = 3,
-        MOCK_BROKER_SFT_FILE_CHUNK__FILE_UNAVAILABLE                         = 4,
-    };
-
-    XI_ALLOC( xi_control_message_t, control_message_reply, state );
-
-    file_chunk_out_artificial =
-        xi_mock_broker_sft_logic_get_reproducible_randomlike_bytes(
-            control_message->file_get_chunk.offset,
-            control_message->file_get_chunk.length );
-
-    control_message_reply->file_chunk = ( struct file_chunk_s ){
-        .common = {.msgtype = XI_CONTROL_MESSAGE_SC__SFT_FILE_CHUNK, .msgver = 1},
-        .name     = control_message->file_get_chunk.name,
-        .revision = control_message->file_get_chunk.revision,
-        .offset   = control_message->file_get_chunk.offset,
-        .length   = control_message->file_get_chunk.length,
-        .status   = MOCK_BROKER_SFT_FILE_CHUNK__REQUEST_IS_CORRECT,
-        .chunk    = file_chunk_out_artificial};
-
-
-    /* prevent deallocation of name and revision since these are reused in reply msg
-     */
-    control_message->file_get_chunk.name     = NULL;
-    control_message->file_get_chunk.revision = NULL;
-
-    return control_message_reply;
-
-err_handling:
-
-    xi_control_message_free( &control_message_reply );
-    XI_SAFE_FREE( file_chunk_out_artificial );
-
-    return NULL;
-}
-
 xi_control_message_t*
 xi_mock_broker_sft_logic_on_file_get_chunk( xi_control_message_t* control_message )
 {
@@ -231,7 +157,7 @@ xi_mock_broker_sft_logic_on_file_get_chunk( xi_control_message_t* control_messag
     if ( NULL == control_message_reply )
     {
         control_message_reply =
-            xi_mock_broker_sft_logic_generate_reply_FILE_CHUNK( control_message );
+            xi_control_message_sft_generate_reply_FILE_CHUNK( control_message );
     }
 
     return control_message_reply;

--- a/src/tests/utests/xi_utest_fwu_checksum.c
+++ b/src/tests/utests/xi_utest_fwu_checksum.c
@@ -45,7 +45,7 @@ XI_TT_TESTCASE_WITH_SETUP(
         uint8_t* checksum     = NULL;
         uint16_t checksum_len = 0;
 
-        xi_bsp_fwu_checksum_final( sha, &checksum, &checksum_len );
+        xi_bsp_fwu_checksum_final( &sha, &checksum, &checksum_len );
 
         tt_int_op( 32, ==, checksum_len );
 

--- a/src/tests/utests/xi_utest_sft_logic.c
+++ b/src/tests/utests/xi_utest_sft_logic.c
@@ -1,0 +1,124 @@
+/* Copyright (c) 2003-2017, LogMeIn, Inc. All rights reserved.
+ *
+ * This is part of the Xively C Client library,
+ * it is licensed under the BSD 3-Clause license.
+ */
+
+#include "tinytest.h"
+#include "tinytest_macros.h"
+#include "xi_tt_testcase_management.h"
+#include "xi_utest_basic_testcase_frame.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include <xi_sft_logic.h>
+#include <xi_macros.h>
+
+#ifndef XI_TT_TESTCASE_ENUMERATION__SECONDPREPROCESSORRUN
+
+#endif
+
+XI_TT_TESTGROUP_BEGIN( utest_sft_logic )
+
+
+XI_TT_TESTCASE_WITH_SETUP( xi_utest__make_context__invalid_paramter,
+                           xi_utest_setup_basic,
+                           xi_utest_teardown_basic,
+                           NULL,
+                           {
+                               const xi_state_t state =
+                                   xi_sft_make_context( NULL, NULL, 0, NULL, NULL );
+
+                               tt_want_ptr_op( XI_INVALID_PARAMETER, ==, state );
+                           } )
+
+XI_TT_TESTCASE_WITH_SETUP(
+    xi_utest__make_context__minimal_config__no_leak_after_deallocation,
+    xi_utest_setup_basic,
+    xi_utest_teardown_basic,
+    NULL,
+    {
+        xi_sft_context_t* sft_context = NULL;
+
+        xi_state_t state = xi_sft_make_context( &sft_context, NULL, 0, NULL, NULL );
+
+        tt_want_ptr_op( XI_STATE_OK, ==, state );
+        tt_want_ptr_op( NULL, !=, sft_context );
+
+        state = xi_sft_free_context( &sft_context );
+
+        tt_want_ptr_op( XI_STATE_OK, ==, state );
+        tt_want_ptr_op( NULL, ==, sft_context );
+    } )
+
+XI_TT_TESTCASE_WITH_SETUP( xi_utest__minimal_config__call_on_connected__no_crash,
+                           xi_utest_setup_basic,
+                           xi_utest_teardown_basic,
+                           NULL,
+                           {
+                               xi_sft_context_t* sft_context = NULL;
+
+                               xi_sft_make_context( &sft_context, NULL, 0, NULL, NULL );
+
+                               xi_sft_on_connected( sft_context );
+
+                               xi_sft_free_context( &sft_context );
+                           } )
+
+XI_TT_TESTCASE_WITH_SETUP( xi_utest__minimal_config__call_on_connection_failed__no_crash,
+                           xi_utest_setup_basic,
+                           xi_utest_teardown_basic,
+                           NULL,
+                           {
+                               xi_sft_context_t* sft_context = NULL;
+
+                               xi_sft_make_context( &sft_context, NULL, 0, NULL, NULL );
+
+                               xi_sft_on_connection_failed( sft_context );
+
+                               xi_sft_free_context( &sft_context );
+                           } )
+
+XI_TT_TESTCASE_WITH_SETUP( xi_utest__minimal_config__call_on_message_with_NULL__no_crash,
+                           xi_utest_setup_basic,
+                           xi_utest_teardown_basic,
+                           NULL,
+                           {
+                               xi_sft_context_t* sft_context = NULL;
+
+                               xi_sft_make_context( &sft_context, NULL, 0, NULL, NULL );
+
+                               xi_sft_on_message( sft_context, NULL );
+
+                               xi_sft_free_context( &sft_context );
+                           } )
+
+XI_TT_TESTCASE_WITH_SETUP(
+    xi_utest__minimal_config__call_on_message_with_uninitialized_message__no_crash,
+    xi_utest_setup_basic,
+    xi_utest_teardown_basic,
+    NULL,
+    {
+        xi_sft_context_t* sft_context = NULL;
+
+        xi_sft_make_context( &sft_context, NULL, 0, NULL, NULL );
+
+        xi_state_t state = XI_STATE_OK;
+
+        XI_ALLOC( xi_control_message_t, message_uninitialized, state );
+
+        xi_sft_on_message( sft_context, message_uninitialized );
+
+    err_handling:
+
+        xi_sft_free_context( &sft_context );
+    } )
+
+XI_TT_TESTGROUP_END
+
+#ifndef XI_TT_TESTCASE_ENUMERATION__SECONDPREPROCESSORRUN
+#define XI_TT_TESTCASE_ENUMERATION__SECONDPREPROCESSORRUN
+#include __FILE__
+#undef XI_TT_TESTCASE_ENUMERATION__SECONDPREPROCESSORRUN
+#endif

--- a/src/tests/utests/xi_utest_sft_logic.c
+++ b/src/tests/utests/xi_utest_sft_logic.c
@@ -14,6 +14,8 @@
 
 #include <xi_sft_logic.h>
 #include <xi_macros.h>
+#include <xi_control_message_sft.h>
+#include <xi_control_message_sft_generators.h>
 
 #ifndef XI_TT_TESTCASE_ENUMERATION__SECONDPREPROCESSORRUN
 
@@ -112,6 +114,28 @@ XI_TT_TESTCASE_WITH_SETUP(
 
     err_handling:
 
+        xi_sft_free_context( &sft_context );
+    } )
+
+XI_TT_TESTCASE_WITH_SETUP(
+    xi_utest__minimal_config__call_on_message_with_FILE_CHUNK__no_crash,
+    xi_utest_setup_basic,
+    xi_utest_teardown_basic,
+    NULL,
+    {
+        xi_sft_context_t* sft_context = NULL;
+
+        xi_sft_make_context( &sft_context, NULL, 0, NULL, NULL );
+
+        xi_control_message_t* message_FILE_GET_CHUNK =
+            xi_control_message_create_file_get_chunk( "filename", "revision", 11, 22 );
+
+        xi_control_message_t* message_FILE_CHUNK =
+            xi_control_message_sft_generate_reply_FILE_CHUNK( message_FILE_GET_CHUNK );
+
+        xi_sft_on_message( sft_context, message_FILE_CHUNK );
+
+        xi_control_message_free( &message_FILE_GET_CHUNK );
         xi_sft_free_context( &sft_context );
     } )
 

--- a/src/tests/utests/xi_utests.c
+++ b/src/tests/utests/xi_utests.c
@@ -67,6 +67,7 @@ XI_TT_TESTCASE_PREDECLARATION( utest_cbor_codec_ct_decode );
 
 #ifdef XI_SECURE_FILE_TRANSFER_ENABLED
 XI_TT_TESTCASE_PREDECLARATION( utest_control_message_sft );
+XI_TT_TESTCASE_PREDECLARATION( utest_sft_logic );
 #endif
 
 #ifdef XI_CONTROL_TOPIC_ENABLED
@@ -259,6 +260,7 @@ struct testgroup_t groups[] = {
     {"utest_cbor_codec_ct_encode - ", utest_cbor_codec_ct_encode},
     {"utest_cbor_codec_ct_decode - ", utest_cbor_codec_ct_decode},
     {"utest_control_message_sft - ", utest_control_message_sft},
+    {"utest_sft_logic - ", utest_sft_logic},
 #endif
 
     END_OF_GROUPS};


### PR DESCRIPTION
[ Description ]
Fixing possible memory leak and not closed file in case SFT package download breaks because socket disconnection. Unit tests were introduced to reproduce in-SFT-process deallocation of SFT logic and checking deallocations afterwards.

[ JIRA ]
SFT feature fix
link: n/a

[ Reviewer ]

[ QA ]
New unit tests were written to cover SFT logic deallocation in the middle of a package download.

[ Release Notes ]
n/a