### PR TITLE
CBOR Assertions Now Only in Debug Mode

### DIFF
--- a/src/import/cn-cbor/src/cn-cbor.c
+++ b/src/import/cn-cbor/src/cn-cbor.c
@@ -11,7 +11,11 @@ extern "C" {
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <assert.h>
+
+#if XI_DEBUG_ASSERT
+  #include <assert.h>
+#endif 
+
 #include <math.h>
 // #include <arpa/inet.h> // needed for ntohl (e.g.) on Linux
 
@@ -22,7 +26,11 @@ extern "C" {
 
 void cn_cbor_free(cn_cbor* cb CBOR_CONTEXT) {
   cn_cbor* p = cb;
+
+#if XI_DEBUG_ASSERT
   assert(!p || !p->parent);
+#endif
+
   while (p) {
     cn_cbor* p1;
     while ((p1 = p->first_child)) { /* go down */

--- a/src/import/cn-cbor/src/cn-cbor.c
+++ b/src/import/cn-cbor/src/cn-cbor.c
@@ -15,7 +15,9 @@ extern "C" {
 #if XI_DEBUG_ASSERT
   #include <assert.h>
 #else
-  #define assert(x)
+  #ifndef assert
+    #define assert(x)
+  #endif
 #endif 
 
 #include <math.h>

--- a/src/import/cn-cbor/src/cn-cbor.c
+++ b/src/import/cn-cbor/src/cn-cbor.c
@@ -14,6 +14,8 @@ extern "C" {
 
 #if XI_DEBUG_ASSERT
   #include <assert.h>
+#else
+  #define assert(x)
 #endif 
 
 #include <math.h>
@@ -26,11 +28,7 @@ extern "C" {
 
 void cn_cbor_free(cn_cbor* cb CBOR_CONTEXT) {
   cn_cbor* p = cb;
-
-#if XI_DEBUG_ASSERT
   assert(!p || !p->parent);
-#endif
-
   while (p) {
     cn_cbor* p1;
     while ((p1 = p->first_child)) { /* go down */

--- a/src/import/cn-cbor/src/cn-encoder.c
+++ b/src/import/cn-cbor/src/cn-encoder.c
@@ -16,7 +16,9 @@ extern "C" {
 #if XI_DEBUG_ASSERT
   #include <assert.h>
 #else
-  #define assert(x)
+  #ifndef assert
+    #define assert(x)
+  #endif
 #endif 
 
 #include "cn-cbor/cn-cbor.h"

--- a/src/import/cn-cbor/src/cn-encoder.c
+++ b/src/import/cn-cbor/src/cn-encoder.c
@@ -12,7 +12,12 @@ extern "C" {
 #include <string.h>
 #include <strings.h>
 #include <stdbool.h>
-#include <assert.h>
+
+#if XI_DEBUG_ASSERT
+  #include <assert.h>
+#else
+  #define assert(x)
+#endif 
 
 #include "cn-cbor/cn-cbor.h"
 #include "cbor.h"
@@ -78,9 +83,7 @@ static inline bool is_indefinite(const cn_cbor *cb)
 
 static void _write_positive(cn_write_state *ws, cn_cbor_type typ, uint64_t val) {
   uint8_t ib;
-
   assert((size_t)typ < sizeof(_xlate));
-
   ib = _xlate[typ];
   if (ib == 0xFF) {
     ws->offset = -1;

--- a/src/import/cn-cbor/src/cn-get.c
+++ b/src/import/cn-cbor/src/cn-get.c
@@ -1,12 +1,19 @@
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
+
+#if XI_DEBUG_ASSERT
+  #include <assert.h>
+#endif
 
 #include "cn-cbor/cn-cbor.h"
 
 cn_cbor* cn_cbor_mapget_int(const cn_cbor* cb, int key) {
   cn_cbor* cp;
+
+#if XI_DEBUG_ASSERT
   assert(cb);
+#endif
+
   for (cp = cb->first_child; cp && cp->next; cp = cp->next->next) {
     switch(cp->type) {
     case CN_CBOR_UINT:
@@ -28,8 +35,12 @@ cn_cbor* cn_cbor_mapget_int(const cn_cbor* cb, int key) {
 cn_cbor* cn_cbor_mapget_string(const cn_cbor* cb, const char* key) {
   cn_cbor *cp;
   int keylen;
+
+#if XI_DEBUG_ASSERT
   assert(cb);
   assert(key);
+#endif
+
   keylen = strlen(key);
   for (cp = cb->first_child; cp && cp->next; cp = cp->next->next) {
     switch(cp->type) {
@@ -51,7 +62,11 @@ cn_cbor* cn_cbor_mapget_string(const cn_cbor* cb, const char* key) {
 cn_cbor* cn_cbor_index(const cn_cbor* cb, unsigned int idx) {
   cn_cbor *cp;
   unsigned int i = 0;
+
+#if XI_DEBUG_ASSERT
   assert(cb);
+#endif
+  
   for (cp = cb->first_child; cp; cp = cp->next) {
     if (i == idx) {
       return cp;

--- a/src/import/cn-cbor/src/cn-get.c
+++ b/src/import/cn-cbor/src/cn-get.c
@@ -3,17 +3,15 @@
 
 #if XI_DEBUG_ASSERT
   #include <assert.h>
-#endif
+#else
+  #define assert(x)
+#endif 
 
 #include "cn-cbor/cn-cbor.h"
 
 cn_cbor* cn_cbor_mapget_int(const cn_cbor* cb, int key) {
   cn_cbor* cp;
-
-#if XI_DEBUG_ASSERT
   assert(cb);
-#endif
-
   for (cp = cb->first_child; cp && cp->next; cp = cp->next->next) {
     switch(cp->type) {
     case CN_CBOR_UINT:
@@ -35,12 +33,8 @@ cn_cbor* cn_cbor_mapget_int(const cn_cbor* cb, int key) {
 cn_cbor* cn_cbor_mapget_string(const cn_cbor* cb, const char* key) {
   cn_cbor *cp;
   int keylen;
-
-#if XI_DEBUG_ASSERT
   assert(cb);
   assert(key);
-#endif
-
   keylen = strlen(key);
   for (cp = cb->first_child; cp && cp->next; cp = cp->next->next) {
     switch(cp->type) {
@@ -62,11 +56,7 @@ cn_cbor* cn_cbor_mapget_string(const cn_cbor* cb, const char* key) {
 cn_cbor* cn_cbor_index(const cn_cbor* cb, unsigned int idx) {
   cn_cbor *cp;
   unsigned int i = 0;
-
-#if XI_DEBUG_ASSERT
   assert(cb);
-#endif
-  
   for (cp = cb->first_child; cp; cp = cp->next) {
     if (i == idx) {
       return cp;

--- a/src/import/cn-cbor/src/cn-get.c
+++ b/src/import/cn-cbor/src/cn-get.c
@@ -4,7 +4,9 @@
 #if XI_DEBUG_ASSERT
   #include <assert.h>
 #else
-  #define assert(x)
+  #ifndef assert
+    #define assert(x)
+  #endif
 #endif 
 
 #include "cn-cbor/cn-cbor.h"


### PR DESCRIPTION
[ Description ]
cn-cbor contains assertions that were active in the release builds of clients. These are now only on when XI_DEBUG_ASSERT is 1 in the build environment.  This is generally only toggled on during debug builds.

[ JIRA ]
None.

[ Reviewer ]
@atigyi

[ QA ]
Built and ran tests with debug and release mode.
added #error test to ensure that the debug assertion preprocessor definitions was toggled on in debug mode.

[ Release Notes ]
Assertions in CBOR encoder have been disabled in release mode.