### PR TITLE
Fix fuzztest fail on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: c
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
     - XI_BSP_TLS=wolfssl
     - XI_MAKETARGET=tests
   matrix:
-    - PRESET=ARM_REL
-    - PRESET=ARM_REL_MIN
+    # - PRESET=ARM_REL
+    # - PRESET=ARM_REL_MIN
 
     # - PRESET=STM32FX
     #   XI_MAKETARGET=""
@@ -24,20 +24,20 @@ env:
     # - PRESET=CC3200_TLS_SOCKET
     #   XI_MAKETARGET=""
 
-    - PRESET=ESP32
-      XI_MAKETARGET=""
+    # - PRESET=ESP32
+    #   XI_MAKETARGET=""
 
-    - PRESET=POSIX_DEV
-    - PRESET=POSIX_DEV_MIN
-    - PRESET=POSIX_REL
-    - PRESET=POSIX_REL_MIN
+    # - PRESET=POSIX_DEV
+    # - PRESET=POSIX_DEV_MIN
+    # - PRESET=POSIX_REL
+    # - PRESET=POSIX_REL_MIN
 
-    - PRESET=POSIX_REL
-      XI_BSP_TLS=mbedtls
+    # - PRESET=POSIX_REL
+    #   XI_BSP_TLS=mbedtls
 
-    - PRESET=POSIX_THREADING_REL
-    - PRESET=POSIX_UNSECURE_REL
-      XI_BSP_TLS=""
+    # - PRESET=POSIX_THREADING_REL
+    # - PRESET=POSIX_UNSECURE_REL
+    #   XI_BSP_TLS=""
 
     - TESTS=fuzztests
       PRESET=FUZZ_TESTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,13 +75,13 @@ matrix:
       env: PRESET=CC3200_TLS_SOCKET XI_MAKETARGET=""
     - compiler: clang
       env: PRESET=ESP32 XI_MAKETARGET=""
-    - compiler: gcc
+    - compiler: clang
       env: TESTS=fuzztests PRESET=FUZZ_TESTS XI_BSP_TLS="" XI_MAKETARGET="fuzz_tests"
 before_script:
   - "if [[ ! $TESTS == 'fuzztests' ]]; then
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
-        if [[ $CC == *'clang'* ]]; then export CC=clang CXX=clang++; fi;
+        export CC=clang CXX=clang++;
      fi"
 script:
   - "set -e"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,9 +81,7 @@ before_script:
   - "if [[ ! $TESTS == 'fuzztests' ]]; then
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
-        # https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection;
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope;
-
         export CC=clang CXX=clang++;
      fi"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,14 +75,14 @@ matrix:
       env: PRESET=CC3200_TLS_SOCKET XI_MAKETARGET=""
     - compiler: clang
       env: PRESET=ESP32 XI_MAKETARGET=""
-    - compiler: clang
+    - compiler: gcc
       env: TESTS=fuzztests PRESET=FUZZ_TESTS XI_BSP_TLS="" XI_MAKETARGET="fuzz_tests"
 before_script:
+  # https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection
   - "if [[ ! $TESTS == 'fuzztests' ]]; then
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope;
-        export CC=clang CXX=clang++;
      fi"
 script:
   - "set -e"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - XI_MAKETARGET=tests
   matrix:
     - PRESET=ARM_REL
-    # - PRESET=ARM_REL_MIN
+    - PRESET=ARM_REL_MIN
 
     # - PRESET=STM32FX
     #   XI_MAKETARGET=""
@@ -24,25 +24,26 @@ env:
     # - PRESET=CC3200_TLS_SOCKET
     #   XI_MAKETARGET=""
 
-    # - PRESET=ESP32
-    #   XI_MAKETARGET=""
-
-    # - PRESET=POSIX_DEV
-    # - PRESET=POSIX_DEV_MIN
-    # - PRESET=POSIX_REL
-    # - PRESET=POSIX_REL_MIN
-
-    # - PRESET=POSIX_REL
-    #   XI_BSP_TLS=mbedtls
-
-    # - PRESET=POSIX_THREADING_REL
-    # - PRESET=POSIX_UNSECURE_REL
-    #   XI_BSP_TLS=""
-
     - TESTS=fuzztests
       PRESET=FUZZ_TESTS
       XI_BSP_TLS=""
       XI_MAKETARGET="fuzz_tests"
+
+    - PRESET=ESP32
+      XI_MAKETARGET=""
+
+    - PRESET=POSIX_DEV
+    - PRESET=POSIX_DEV_MIN
+    - PRESET=POSIX_REL
+    - PRESET=POSIX_REL_MIN
+
+    - PRESET=POSIX_REL
+      XI_BSP_TLS=mbedtls
+
+    - PRESET=POSIX_THREADING_REL
+    - PRESET=POSIX_UNSECURE_REL
+      XI_BSP_TLS=""
+
 cache:
     apt
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: true
+sudo: false
 language: c
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,6 @@ env:
     # - PRESET=CC3200_TLS_SOCKET
     #   XI_MAKETARGET=""
 
-    - TESTS=fuzztests
-      PRESET=FUZZ_TESTS
-      XI_BSP_TLS=""
-      XI_MAKETARGET="fuzz_tests"
-
     - PRESET=ESP32
       XI_MAKETARGET=""
 
@@ -43,6 +38,11 @@ env:
     - PRESET=POSIX_THREADING_REL
     - PRESET=POSIX_UNSECURE_REL
       XI_BSP_TLS=""
+
+    - TESTS=fuzztests
+      PRESET=FUZZ_TESTS
+      XI_BSP_TLS=""
+      XI_MAKETARGET="fuzz_tests"
 
 cache:
     apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ before_script:
   - "if [[ ! $TESTS == 'fuzztests' ]]; then
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
-        # https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection
+        # https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection;
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope;
 
         export CC=clang CXX=clang++;

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
       PRESET=FUZZ_TESTS
       XI_BSP_TLS=""
       XI_MAKETARGET="fuzz_tests"
+      CXX=clang++
 
 cache:
     apt
@@ -77,14 +78,13 @@ matrix:
     - compiler: clang
       env: PRESET=ESP32 XI_MAKETARGET=""
     - compiler: gcc
-      env: TESTS=fuzztests PRESET=FUZZ_TESTS XI_BSP_TLS="" XI_MAKETARGET="fuzz_tests"
+      env: TESTS=fuzztests PRESET=FUZZ_TESTS XI_BSP_TLS="" XI_MAKETARGET="fuzz_tests" CXX=clang++
 before_script:
   # https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection
   - "if [[ ! $TESTS == 'fuzztests' ]]; then
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope;
-        export CXX=clang++;
      fi"
 script:
   - "set -e"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ before_script:
   - "if [[ ! $TESTS == 'fuzztests' ]]; then
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
+        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
         export CC=clang CXX=clang++;
      fi"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ before_script:
         cat /proc/sys/kernel/yama/ptrace_scope;
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope;
         cat /proc/sys/kernel/yama/ptrace_scope;
+
         export CC=clang CXX=clang++;
      fi"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ before_script:
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope;
+        export CXX=clang++;
      fi"
 script:
   - "set -e"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,9 @@ before_script:
   - "if [[ ! $TESTS == 'fuzztests' ]]; then
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
+        # https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope;
+
         export CC=clang CXX=clang++;
      fi"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - XI_BSP_TLS=wolfssl
     - XI_MAKETARGET=tests
   matrix:
-    # - PRESET=ARM_REL
+    - PRESET=ARM_REL
     # - PRESET=ARM_REL_MIN
 
     # - PRESET=STM32FX

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,10 +81,7 @@ before_script:
   - "if [[ ! $TESTS == 'fuzztests' ]]; then
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
-        cat /proc/sys/kernel/yama/ptrace_scope;
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope;
-        cat /proc/sys/kernel/yama/ptrace_scope;
-
         export CC=clang CXX=clang++;
      fi"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,9 @@ before_script:
   - "if [[ ! $TESTS == 'fuzztests' ]]; then
         if [[ $CC == *'clang'* ]]; then export CC='clang-3.8'; fi;
      else
-        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+        cat /proc/sys/kernel/yama/ptrace_scope;
+        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope;
+        cat /proc/sys/kernel/yama/ptrace_scope;
         export CC=clang CXX=clang++;
      fi"
 script:

--- a/Makefile
+++ b/Makefile
@@ -200,12 +200,11 @@ $(XI_FUZZ_TESTS_BINDIR)/%: $(XI_FUZZ_TESTS_SOURCE_DIR)/%.cpp
 	$(CXX) --version
 	$(MD) $(CXX) $< $(XI_CONFIG_FLAGS) $(XI_INCLUDE_FLAGS) -L$(XI_BINDIR) -L$(XI_LIBFUZZER_DOWNLOAD_DIR) $(XI_LIB_FLAGS) $(XI_FUZZ_TEST_LIBRARY) $(XI_COMPILER_OUTPUT)
 
-.PHONY: fuzz_tests
-
-fuzz_tests: $(XI_LIBFUZZER) $(XI_FUZZ_TESTS) $(XI_FUZZ_TESTS_CORPUS_DIRS) $(XI)
-	$(foreach fuzztest, $(XI_FUZZ_TESTS), $(call XI_RUN_FUZZ_TEST,$(fuzztest)))
-
 $(XI_FUZZ_TESTS): $(XI)
+
+.PHONY: fuzz_tests
+fuzz_tests: $(XI_LIBFUZZER) $(XI_FUZZ_TESTS) $(XI_FUZZ_TESTS_CORPUS_DIRS)
+	$(foreach fuzztest, $(XI_FUZZ_TESTS), $(call XI_RUN_FUZZ_TEST,$(fuzztest)))
 
 .PHONY: static_analysis
 static_analysis:  $(XI_SOURCES:.c=.sa)

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,8 @@ $(XI_OBJDIR)/tests/tools/xi_libxively_driver/%.o : $(LIBXIVELY)/src/tests/tools/
 $(XI_OBJDIR)/%.o : $(LIBXIVELY)/src/%.c $(XI_BUILD_PRECONDITIONS)
 	@-mkdir -p $(dir $@)
 	$(info [$(CC)] $@)
+	which $(CC)
+	$(CC) --version
 	$(MD) $(CC) $(XI_CONFIG_FLAGS) $(XI_COMPILER_FLAGS) $(XI_INCLUDE_FLAGS) -c $< $(XI_COMPILER_OUTPUT)
 	$(XI_POST_COMPILE_ACTION)
 
@@ -194,6 +196,8 @@ endif
 $(XI_FUZZ_TESTS_BINDIR)/%: $(XI_FUZZ_TESTS_SOURCE_DIR)/%.cpp
 	@-mkdir -p $(dir $@)
 	$(info [$(CXX)] $@)
+	which $(CXX)
+	$(CXX) --version
 	$(MD) $(CXX) $< $(XI_CONFIG_FLAGS) $(XI_INCLUDE_FLAGS) -L$(XI_BINDIR) -L$(XI_LIBFUZZER_DOWNLOAD_DIR) $(XI_LIB_FLAGS) $(XI_FUZZ_TEST_LIBRARY) $(XI_COMPILER_OUTPUT)
 
 .PHONY: fuzz_tests

--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,6 @@ $(XI_OBJDIR)/tests/tools/xi_libxively_driver/%.o : $(LIBXIVELY)/src/tests/tools/
 $(XI_OBJDIR)/%.o : $(LIBXIVELY)/src/%.c $(XI_BUILD_PRECONDITIONS)
 	@-mkdir -p $(dir $@)
 	$(info [$(CC)] $@)
-	which $(CC)
-	$(CC) --version
 	$(MD) $(CC) $(XI_CONFIG_FLAGS) $(XI_COMPILER_FLAGS) $(XI_INCLUDE_FLAGS) -c $< $(XI_COMPILER_OUTPUT)
 	$(XI_POST_COMPILE_ACTION)
 
@@ -196,8 +194,6 @@ endif
 $(XI_FUZZ_TESTS_BINDIR)/%: $(XI_FUZZ_TESTS_SOURCE_DIR)/%.cpp
 	@-mkdir -p $(dir $@)
 	$(info [$(CXX)] $@)
-	which $(CXX)
-	$(CXX) --version
 	$(MD) $(CXX) $< $(XI_CONFIG_FLAGS) $(XI_INCLUDE_FLAGS) -L$(XI_BINDIR) -L$(XI_LIBFUZZER_DOWNLOAD_DIR) $(XI_LIB_FLAGS) $(XI_FUZZ_TEST_LIBRARY) $(XI_COMPILER_OUTPUT)
 
 $(XI_FUZZ_TESTS): $(XI)

--- a/make/mt-config/mt-presets.mk
+++ b/make/mt-config/mt-presets.mk
@@ -151,9 +151,6 @@ else ifeq ($(PRESET), ESP32_DEV)
 # -------------------------------------------------------
 # Fuzz Tests
 else ifeq ($(PRESET), FUZZ_TESTS)
-	ifeq ($(XI_HOST_PLATFORM),Darwin)
-$(error Fuzz testing won\'t work on OSX)
-	endif
 	CONFIG = $(CONFIG_POSIX_MIN_UNSECURE)_fuzz_test
 	TARGET = $(TARGET_STATIC_REL)
 	XI_BSP_PLATFORM = posix

--- a/make/mt-config/tests/mt-tests-fuzz.mk
+++ b/make/mt-config/tests/mt-tests-fuzz.mk
@@ -57,13 +57,9 @@ $(XI_LIBFUZZER_DOWNLOAD_DIR):
 	@-mkdir -p $(XI_LIBFUZZER_DOWNLOAD_DIR)
 	svn checkout $(XI_LIBFUZZER_URL) $(XI_LIBFUZZER_DOWNLOAD_DIR)
 
-$(XI_LIBFUZZER): $(XI_CLANG_COMPILER) $(XI_LIBFUZZER_DOWNLOAD_DIR)
+# $(XI_LIBFUZZER): $(XI_CLANG_COMPILER) $(XI_LIBFUZZER_DOWNLOAD_DIR)
+$(XI_LIBFUZZER): $(XI_LIBFUZZER_DOWNLOAD_DIR)
 	(cd $(XI_LIBFUZZER_DOWNLOAD_DIR) && clang++ -c -g -O2 -lstdc++ -std=c++11 *.cpp -IFuzzer && ar ruv libFuzzer.a Fuzzer*.o)
 
 $(XI_FUZZ_TESTS_CORPUS_DIRS):
 	@-mkdir -p $@
-
-#### =========================================================
-
-
-build_libfuzzer: $(XI_LIBFUZZER)

--- a/make/mt-config/tests/mt-tests-fuzz.mk
+++ b/make/mt-config/tests/mt-tests-fuzz.mk
@@ -22,32 +22,6 @@ XI_FUZZ_TEST_LIBRARY := -lFuzzer
 #### =========================================================
 
 XI_CLANG_TOOLS_DIR := $(LIBXIVELY)/src/import/clang_tools
-XI_CLANG_COMPILER_DOWNLOAD_DIR := $(XI_CLANG_TOOLS_DIR)/downloaded_clang_compiler
-XI_CLANG_COMPILER_INSTALL_DIR := $(XI_CLANG_TOOLS_DIR)/third_party/llvm-build/Release+Asserts
-XI_CLANG_COMPILER := $(XI_CLANG_COMPILER_INSTALL_DIR)/bin/clang
-
-# This is where the compiler path is being overriden
-ifneq (,$(findstring fuzz_test,$(CONFIG)))
-	# export PATH := $(XI_CLANG_COMPILER_INSTALL_DIR)/bin:$(PATH)
-endif
-
-
-CLANG_REPOSITORY_URL=https://chromium.googlesource.com/chromium/src/tools/clang
-
-$(XI_CLANG_COMPILER_DOWNLOAD_DIR):
-	@-mkdir -p $(XI_CLANG_COMPILER_DOWNLOAD_DIR)
-	(cd $(XI_CLANG_COMPILER_DOWNLOAD_DIR) && git clone $(CLANG_REPOSITORY_URL) && cd clang && git checkout 37d701b87a10a2bdee1a5c3523f754ebf64a7e66 )
-
-$(XI_CLANG_COMPILER_INSTALL_DIR): $(XI_CLANG_COMPILER_DOWNLOAD_DIR)
-	(cd $(XI_CLANG_COMPILER_DOWNLOAD_DIR) && python2 clang/scripts/update.py)
-
-$(XI_CLANG_COMPILER): $(XI_CLANG_COMPILER_INSTALL_DIR)
-
-add_clang_to_path: $(XI_CLANG_COMPILER)
-
-clang_compiler: add_clang_to_path
-
-#### =========================================================
 
 XI_LIBFUZZER_URL := https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer
 XI_LIBFUZZER_DOWNLOAD_DIR := $(XI_CLANG_TOOLS_DIR)/downloaded_libfuzzer
@@ -57,7 +31,6 @@ $(XI_LIBFUZZER_DOWNLOAD_DIR):
 	@-mkdir -p $(XI_LIBFUZZER_DOWNLOAD_DIR)
 	svn checkout $(XI_LIBFUZZER_URL) $(XI_LIBFUZZER_DOWNLOAD_DIR)
 
-# $(XI_LIBFUZZER): $(XI_CLANG_COMPILER) $(XI_LIBFUZZER_DOWNLOAD_DIR)
 $(XI_LIBFUZZER): $(XI_LIBFUZZER_DOWNLOAD_DIR)
 	(cd $(XI_LIBFUZZER_DOWNLOAD_DIR) && clang++ -c -g -O2 -lstdc++ -std=c++11 *.cpp -IFuzzer && ar ruv libFuzzer.a Fuzzer*.o)
 

--- a/make/mt-config/tests/mt-tests-fuzz.mk
+++ b/make/mt-config/tests/mt-tests-fuzz.mk
@@ -28,7 +28,7 @@ XI_CLANG_COMPILER := $(XI_CLANG_COMPILER_INSTALL_DIR)/bin/clang
 
 # This is where the compiler path is being overriden
 ifneq (,$(findstring fuzz_test,$(CONFIG)))
-	export PATH := $(XI_CLANG_COMPILER_INSTALL_DIR)/bin:$(PATH)
+	# export PATH := $(XI_CLANG_COMPILER_INSTALL_DIR)/bin:$(PATH)
 endif
 
 


### PR DESCRIPTION
[ Description ]
There is a fuzz test target which gets built and run by Mr. Travis CI. The execution of this build failed before, with this change it works again.
Details: during it's run libfuzzer uses ptrace to monitor different aspects of the instrumented library / application, from a different thread I guess, maybe different process. Examining non-child processes or threads are disabled in linux kernel beginning with kernel version 10.10: https://wiki.ubuntu.com/SecurityTeam/Roadmap/KernelHardening#ptrace_Protection

Perfect solution would be changing libfuzzer to spawn System Under Test thread from the ptrace thread but I haven't chosen this. There is a fast workaround described in the link above: re-enabling user space processes to ptrace each other.

Also special, github version of clang is not needed anymore since recent clang releases already contain instrumentation flags required by libfuzzer. Also macOS' llvm compiler is able to compile with fuzzer flags, so fuzzing is also available on macOS. So this part is removed from the fuzztest makefile.

[ JIRA ]
n/a

[ Reviewer ]
@Palantir555

[ QA ]
Travis is able to run the fuzz test binary without an issue.

[ Release Notes ]
n/a