### PR TITLE
Release/v1.3.3

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,7 +10,7 @@
 
 ## Bugfix
 - [ESP32] Fix integer overflow in time BSP.
-- [ESP32/CC3200] Fix FWU Board Support Packages for SFT when running an SFT migration that does not include new firmware binaries. Previously the device rebooted at switched boot partitions upon all SFT deliveries, now this nly occurs if a new firmware image is downloaded.
+- [ESP32/CC3200] Fix FWU Board Support Packages for SFT when running an SFT migration that does not include new firmware binaries. Previously the device rebooted at switched boot partitions upon all SFT deliveries, now this only occurs if a new firmware image is downloaded.
 - [WolfSSL] `src\import\tls\wolfssl.conf` configuration script errantly defined --enable-debug twice.
 
 ### Misc

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,7 +10,7 @@
 
 ## Bugfix
 - [ESP32] Fix integer overflow in time BSP.
-- [ESP32/CC3200] Fix FWU Board Support Packages for SFT when running an SFT migration that does not include new firmware binaries. Previously the device rebooted upon all SFT deliveries, now it's only rebooted if a new firmware image was downloaded.
+- [ESP32/CC3200] Fix FWU Board Support Packages for SFT when running an SFT migration that does not include new firmware binaries. Previously the device rebooted at switched boot partitions upon all SFT deliveries, now this nly occurs if a new firmware image is downloaded.
 - [WolfSSL] `src\import\tls\wolfssl.conf` configuration script errantly defined --enable-debug twice.
 
 ### Misc

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,15 +4,13 @@
 ## Features
 - [CC3220SF] Updated example application support to TI SimpleLink SDK 1.6, XDC Tools version 3.50.04.43.
 - [CC3220SF] Example application now detects WiFi disconnections and cleanly reconnects when WiFi AP returns.
-
 - [ESP32] Updated the Xively C Client build to work with IDF SDK: Master commit af63ca1
-- [ESP32] Improve LED signaling in demo application.
-
-- [Secure File Transfer] CBOR library assertions are no suppressed.  They can be enabled by defining `XI_DEBUG_ASSERT=1` on the make command line when building the library. 
+- [ESP32] Improved LED signaling in demo application.
+- [Secure File Transfer] CBOR library assertions are now suppressed.  They can be enabled by defining `XI_DEBUG_ASSERT=1` on the make command line when building the Xively C Client library. 
 
 ## Bugfix
-- [ESP32] Fix int overflow in time BSP.
-- [ESP32/CC3200] Fix FWU BSPs for SFT packages without firmware binaries. Only commit/reboot if a new firmware image was downloaded.
+- [ESP32] Fix integer overflow in time BSP.
+- [ESP32/CC3200] Fix FWU Board Support Packages for SFT when running an SFT migration that does not include new firmware binaries. Previously the device rebooted upon all SFT deliveries, now it's only rebooted if a new firmware image was downloaded.
 - [WolfSSL] `src\import\tls\wolfssl.conf` configuration script errantly defined --enable-debug twice.
 
 ### Misc

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,26 @@
+# Xively Client version 1.3.3
+#### Jan 22 2018
+
+## Features
+- [CC3220SF] Updated example application support to TI SimpleLink SDK 1.6, XDC Tools version 3.50.04.43.
+- [CC3220SF] Example application now detects WiFi disconnections and cleanly reconnects when WiFi AP returns.
+
+- [ESP32] Updated the Xively C Client build to work with IDF SDK: Master commit af63ca1
+- [ESP32] Improve LED signaling in demo application.
+
+- [Secure File Transfer] CBOR library assertions are no suppressed.  They can be enabled by defining `XI_DEBUG_ASSERT=1` on the make command line when building the library. 
+
+## Bugfix
+- [ESP32] Fix int overflow in time BSP.
+- [ESP32/CC3200] Fix FWU BSPs for SFT packages without firmware binaries. Only commit/reboot if a new firmware image was downloaded.
+- [WolfSSL] `src\import\tls\wolfssl.conf` configuration script errantly defined --enable-debug twice.
+
+### Misc
+- Removed legacy `Licenses` directory.  All licenses are now in `LICENSE.md` of the base directory of the repository.
+- Updated Copyright Header to 2018.
+- Travis CI configuration changes to FuzzTest Environment.
+- Moved the `cc3200\xively_firmware_updates` to `src\experimental\cc3200\xively_sft_external_client`. This external client application is not our standard Secure File Transfer client, but instead serves as a reference for those who would like to implement SFT on another MQTT client or in another language.  Specifically it demonstrates how to use the CBOR encoder to handle SFT Service Requests and Responses over MQTT. This implementation was moved from our examples directory as it was being confused with our CC3200 SFT implementation via our Board Support Packages (FWU and FS BSPs).  This experimental application will not be kept up to date.  Further development using the Xively C Client SFT feature should be done inside the BSPs of the respective platforms, such as in `src\bsp\platform\cc3200\xi_bsp_fw_cc3200.c` and `src\bsp\platform\cc3200\xi_bsp_io_fs_cc3200.c`.
+
 # Xively Client version 1.3.2
 #### Nov 24 2017
 

--- a/doc/doxygen/api/html/dc/d72/xively_8h.html
+++ b/doc/doxygen/api/html/dc/d72/xively_8h.html
@@ -682,7 +682,7 @@ Variables</h2></td></tr>
 </div><div class="memdoc">
 
 <p>Causes the Xively Client event loop to exit. </p>
-<p>Pending scehduled events will not be invoked again until the event loop is inovked again via xi_events_process.</p>
+<p>Pending scehduled events will not be invoked again until the event loop is invoked again via xi_events_process.</p>
 <p>Stop is often called by the client application when shuttdown its connectivity to the Xively Service. The Xively Client might also call stop if there's an unrecoverable error.</p>
 <dl class="section see"><dt>See also</dt><dd><a class="el" href="../../dc/d72/xively_8h.html#a43533e584acd0e893eb08b11f5823f46" title="Invokes the Xively Event Processing loop. ">xi_events_process_blocking</a> </dd>
 <dd>

--- a/src/libxively/xi_version.h
+++ b/src/libxively/xi_version.h
@@ -9,6 +9,6 @@
 
 #define XI_MAJOR 1
 #define XI_MINOR 3
-#define XI_REVISION 2
+#define XI_REVISION 3
 
 #endif /* __XI_VERSION_H__ */


### PR DESCRIPTION
# Xively Client version 1.3.3
#### Jan 22 2018

## Features
- [CC3220SF] Updated example application support to TI SimpleLink SDK 1.6, XDC Tools version 3.50.04.43.
- [CC3220SF] Example application now detects WiFi disconnections and cleanly reconnects when WiFi AP returns.
- [ESP32] Updated the Xively C Client build to work with IDF SDK: Master commit af63ca1
- [ESP32] Improved LED signaling in demo application.
- [Secure File Transfer] CBOR library assertions are now suppressed.  They can be enabled by defining `XI_DEBUG_ASSERT=1` on the make command line when building the Xively C Client library. 

## Bugfix
- [ESP32] Fix integer overflow in time BSP.
- [ESP32/CC3200] Fix FWU Board Support Packages for SFT when running an SFT migration that does not include new firmware binaries. Previously the device rebooted at switched boot partitions upon all SFT deliveries, now this only occurs if a new firmware image is downloaded.
- [WolfSSL] `src\import\tls\wolfssl.conf` configuration script errantly defined --enable-debug twice.

### Misc
- Removed legacy `Licenses` directory.  All licenses are now in `LICENSE.md` of the base directory of the repository.
- Updated Copyright Header to 2018.
- Travis CI configuration changes to FuzzTest Environment.
- Moved the `cc3200\xively_firmware_updates` to `src\experimental\cc3200\xively_sft_external_client`. This external client application is not our standard Secure File Transfer client, but instead serves as a reference for those who would like to implement SFT on another MQTT client or in another language.  Specifically it demonstrates how to use the CBOR encoder to handle SFT Service Requests and Responses over MQTT. This implementation was moved from our examples directory as it was being confused with our CC3200 SFT implementation via our Board Support Packages (FWU and FS BSPs).  This experimental application will not be kept up to date.  Further development using the Xively C Client SFT feature should be done inside the BSPs of the respective platforms, such as in `src\bsp\platform\cc3200\xi_bsp_fw_cc3200.c` and `src\bsp\platform\cc3200\xi_bsp_io_fs_cc3200.c`.