### PR TITLE
"more" robust Travis, removing gcc-6 and g++-6 package dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,6 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - clang-3.8
-      - gcc-6
-      - g++-6
       - qemu-system
       - libc6:i386
       - expect


### PR DESCRIPTION
[ Description ]
Travis CI had hard times to install gcc-6 and g++-6 packages with `apt-get install`. And actually this *-6 package is unavailable for 14.04.05 LTS ubuntu. At least it seems so on my virtual image. Anyway, even if it found "somehow" the 4.8.5 version gcc was used according to the logs. So it seems it was an unused dependency introduced on 12/06/2016:

Commit: 185d6dd10a465dc5d4634c622383564c73072e5d [185d6dd]
Parents: fb0a0f42cbda30bb1c8998df4a1077ec8036d0c5
Author: olgierdh <olgierd.humenczuk@logmein.com>
Date: 2016. December 5. 13:55:37 GMT+1
Commit Date: 2016. December 6. 15:19:30 GMT+1

[ JIRA ]
n/a

[ Reviewer ]
@DellaBitta 
@palantir555

[ QA ]
Travis builds pass higher ratio. Seems the logs are the same for before and after versions.

[ Release Notes ]
n/a