### PR TITLE
Support linking/including TLS libs outside xively-client-c

### DIFF
--- a/make/mt-config/mt-presets.mk
+++ b/make/mt-config/mt-presets.mk
@@ -142,12 +142,14 @@ else ifeq ($(PRESET), ESP32)
     TARGET = $(TARGET_STATIC_REL)
     XI_BSP_PLATFORM = esp32
     XI_TARGET_PLATFORM = esp32
+    XI_USE_EXTERNAL_TLS_LIB = 1
 
 else ifeq ($(PRESET), ESP32_DEV)
     CONFIG = $(CONFIG_ESP32)
     TARGET = $(TARGET_STATIC_DEV)
     XI_BSP_PLATFORM = esp32
     XI_TARGET_PLATFORM = esp32
+    XI_USE_EXTERNAL_TLS_LIB = 1
 # -------------------------------------------------------
 # Fuzz Tests
 else ifeq ($(PRESET), FUZZ_TESTS)

--- a/make/mt-config/mt-presets.mk
+++ b/make/mt-config/mt-presets.mk
@@ -142,14 +142,18 @@ else ifeq ($(PRESET), ESP32)
     TARGET = $(TARGET_STATIC_REL)
     XI_BSP_PLATFORM = esp32
     XI_TARGET_PLATFORM = esp32
-    XI_USE_EXTERNAL_TLS_LIB = 1
+    ifeq ($(XI_BSP_TLS),mbedtls)
+        XI_USE_EXTERNAL_TLS_LIB = 1
+    endif
 
 else ifeq ($(PRESET), ESP32_DEV)
     CONFIG = $(CONFIG_ESP32)
     TARGET = $(TARGET_STATIC_DEV)
     XI_BSP_PLATFORM = esp32
     XI_TARGET_PLATFORM = esp32
-    XI_USE_EXTERNAL_TLS_LIB = 1
+    ifeq ($(XI_BSP_TLS),mbedtls)
+        XI_USE_EXTERNAL_TLS_LIB = 1
+    endif
 # -------------------------------------------------------
 # Fuzz Tests
 else ifeq ($(PRESET), FUZZ_TESTS)

--- a/make/mt-config/mt-presets.mk
+++ b/make/mt-config/mt-presets.mk
@@ -143,7 +143,7 @@ else ifeq ($(PRESET), ESP32)
     XI_BSP_PLATFORM = esp32
     XI_TARGET_PLATFORM = esp32
     ifeq ($(XI_BSP_TLS),mbedtls)
-        XI_USE_EXTERNAL_TLS_LIB = 1
+        XI_USE_EXTERNAL_TLS_LIB ?= 1
     endif
 
 else ifeq ($(PRESET), ESP32_DEV)
@@ -152,7 +152,7 @@ else ifeq ($(PRESET), ESP32_DEV)
     XI_BSP_PLATFORM = esp32
     XI_TARGET_PLATFORM = esp32
     ifeq ($(XI_BSP_TLS),mbedtls)
-        XI_USE_EXTERNAL_TLS_LIB = 1
+        XI_USE_EXTERNAL_TLS_LIB ?= 1
     endif
 # -------------------------------------------------------
 # Fuzz Tests

--- a/make/mt-config/mt-tls.mk
+++ b/make/mt-config/mt-tls.mk
@@ -4,18 +4,23 @@
 # it is licensed under the BSD 3-Clause license.
 
 # pick the proper configuration file for TLS library
-XI_TLS_LIB_CONFIG_FNAME ?= make/mt-config/mt-tls-$(XI_BSP_TLS).mk
 
+ifneq ($(XI_USE_EXTERNAL_TLS_LIB),1)
+#If using XI_USE_EXTERNAL_TLS_LIB, you'll need to provide XI_TLS_LIB_INC_DIR
+XI_TLS_LIB_CONFIG_FNAME ?= make/mt-config/mt-tls-$(XI_BSP_TLS).mk
 include $(XI_TLS_LIB_CONFIG_FNAME)
+
+TLS_LIB_PATH := $(LIBXIVELY_SRC)import/tls/$(XI_BSP_TLS)
+endif
 
 XI_INCLUDE_FLAGS += -I$(XI_TLS_LIB_INC_DIR)
 
 XI_LIB_FLAGS += $(foreach d, $(XI_TLS_LIB_NAME), -l$d)
 XI_LIB_FLAGS += -L$(XI_TLS_LIB_BIN_DIR)
 
-TLS_LIB_PATH := $(LIBXIVELY_SRC)import/tls/$(XI_BSP_TLS)
-
 ifneq (,$(findstring Windows,$(XI_HOST_PLATFORM)))
+    TLS_LIB_PREPARE_CMD :=
+else ifeq ($(XI_USE_EXTERNAL_TLS_LIB),1)
     TLS_LIB_PREPARE_CMD :=
 else
     TLS_LIB_PREPARE_CMD := (cd $(LIBXIVELY_SRC)/import/tls/ && ./download_and_compile_$(XI_BSP_TLS).sh)

--- a/make/mt-os/mt-esp32.mk
+++ b/make/mt-os/mt-esp32.mk
@@ -102,6 +102,14 @@ endif
 # mt-tls-mbedtls-esp32.mk. Or delete the line below to turn off TLS lib cross compilation.
 include make/mt-config/mt-tls-$(XI_BSP_TLS)-esp32.mk
 
+ifeq ($(XI_BSP_TLS),wolfssl)
+# WolfSSL TLS BSP configuration
+XI_CONFIG_FLAGS += -DXI_PROVIDE_WOLFSSL_SEED_GENERATOR
+XI_CONFIG_FLAGS += -DXI_PROVIDE_WOLFSSL_XTIME_XGMTIME
+else ifeq ($(XI_BSP_TLS),mbedtls)
+XI_TLS_LIB_INC_DIR = $(IDF_PATH)/components/mbedtls/include
+endif
+
 ##################
 # Libxively Config
 ##################

--- a/make/mt-os/mt-esp32.mk
+++ b/make/mt-os/mt-esp32.mk
@@ -103,11 +103,13 @@ endif
 include make/mt-config/mt-tls-$(XI_BSP_TLS)-esp32.mk
 
 ifeq ($(XI_BSP_TLS),wolfssl)
-# WolfSSL TLS BSP configuration
-XI_CONFIG_FLAGS += -DXI_PROVIDE_WOLFSSL_SEED_GENERATOR
-XI_CONFIG_FLAGS += -DXI_PROVIDE_WOLFSSL_XTIME_XGMTIME
+    # WolfSSL TLS BSP configuration
+    XI_CONFIG_FLAGS += -DXI_PROVIDE_WOLFSSL_SEED_GENERATOR
+    XI_CONFIG_FLAGS += -DXI_PROVIDE_WOLFSSL_XTIME_XGMTIME
 else ifeq ($(XI_BSP_TLS),mbedtls)
-XI_TLS_LIB_INC_DIR = $(IDF_PATH)/components/mbedtls/include
+    ifeq ($(XI_USE_EXTERNAL_TLS_LIB),1)
+        XI_TLS_LIB_INC_DIR = $(IDF_PATH)/components/mbedtls/include
+    endif
 endif
 
 ##################


### PR DESCRIPTION
[ Description ]

Until now, libxively would download, include and configure (via build options) whichever TLS library is selected in `XI_BSP_TLS`. That was OK because we were using our own versions of mbedTLS and WolfSSL, and we could decide the build configuration.

Now, the ESP32 SDK contains a pre-built, pre-configured and hardware-accelerated  mbedTLS, so we'd like to avoid downloading/compiling/linking our own version. There are 4 steps to this implementation:

1. Create a new build option that can be set for a given PRESET/XI_BSP_TLS combination
2. Avoid downloading the TLS library when such flag is enabled. Achieved by not setting TLS_LIB_PREPARE_CMD
3. Avoid building libxively's TLS BSP with incompatible build options by removing the inclusion of `make/mt-config/mt-tls-$(XI_BSP_TLS).mk`
3. Set your custom XI_TLS_LIB_INC_DIR path to the TLS library when the flag is set.

[ JIRA ]

[ Reviewer ]
@atigyi

[ QA ]
I'm using this patch to successfully build the ESP32 PRESET using the IDF SDK's mbedTLS.
It's automatically disabled when building for XI_BSP_TLS=wolfssl, and that works fine too.

[ Release Notes ]
Support linking and inclusion of TLS libraries outside the xively-client-c directory. This is part of the effort to get the ESP32 running its SDK's version of mbedTLS, as opposed of downloading and building our own.