### PR TITLE
Fix MQTT connection after AP reconnect in CC3220SF demo

### DIFF
--- a/examples/cc3220sf/xively_demo/.project
+++ b/examples/cc3220sf/xively_demo/.project
@@ -4,6 +4,7 @@
 	<comment></comment>
 	<projects>
 		<project>tirtos_builds_CC3220SF_LAUNCHXL_release_ccs</project>
+		<project>tirtos_builds_CC3220SF_LAUNCHXL_debug_ccs</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>
@@ -28,7 +29,7 @@
 	<variableList>
 		<variable>
 			<name>XIVELY_LIBRARY_C_ROOT</name>
-			<value>file:/E:/dev/xively/xively-client-c</value>
+			<value>$%7BPARENT-3-PROJECT_LOC%7D</value>
 		</variable>
 	</variableList>
 </projectDescription>

--- a/examples/cc3220sf/xively_demo/xively_example.c
+++ b/examples/cc3220sf/xively_demo/xively_example.c
@@ -426,6 +426,9 @@ void* xivelyExampleThread( void* arg )
 
         /* shutdown the xively library */
         xi_shutdown();
+
+        sl_Stop(5);
+        simpleLinkMode = sl_Start( NULL, NULL, NULL );
     }
 }
 


### PR DESCRIPTION
[ Description ]

Previous behaviour:

1. WiFi connection OK
2. MQTT connection OK
3. [wifi AP disconnected - device's connection drops]
4. [wifi AP reconnected]
5. WiFi reconnection OK
6. **MQTT never reconnects** 

By restarting the simplelink interface, we're able to reconnect to MQTT.
This is a workaround-- For a proper fix we'll have to debug the root cause, but this PR gets the device running until we have time for that.

[ JIRA ]

[ Reviewer ]
@DellaBitta

[ QA ]
Ran the application before and after the patch. The issue is resolved by this workaround.

[ Release Notes ]
Work around MQTT reconnection problems in the CC3220SF demo. Before, it would fail to reconnect to the broker after a WiFi drop