### PR TITLE
[ API change ] xi_initialize: removal of device id since it is alread…

### DIFF
--- a/examples/cc3200/xively_demo/main.c
+++ b/examples/cc3200/xively_demo/main.c
@@ -444,7 +444,7 @@ void ConnectToXively()
     /* Disable the interrupt for now */
     Button_IF_DisableInterrupt( SW2 | SW3 );
 
-    xi_state_t ret_state = xi_initialize( XIVELY_ACCOUNT_ID, XIVELY_DEVICE_ID );
+    xi_state_t ret_state = xi_initialize( XIVELY_ACCOUNT_ID );
 
     if ( XI_STATE_OK != ret_state )
     {

--- a/examples/cc3220sf/xively_demo/xively_example.c
+++ b/examples/cc3220sf/xively_demo/xively_example.c
@@ -365,42 +365,46 @@ void* xivelyExampleThread( void* arg )
     while ( 1 == 1 )
     {
         /* Attempt to connect to the configured WiFi network */
-        gApplicationControlBlock.initializationState = InitializationState_ConnectingToWifi;
+        gApplicationControlBlock.initializationState =
+            InitializationState_ConnectingToWifi;
 
         /* Reset The state of the machine                                         */
         Network_IF_ResetMCUStateMachine();
 
         /* Start the driver                                                       */
-        retval = Network_IF_InitDriver(simpleLinkMode, ROLE_STA,
-                                       Callback_ConnectedToWiFi,
-                                       Callback_LostWiFiConnection );
-        if (retval < 0)
+        retval =
+            Network_IF_InitDriver( simpleLinkMode, ROLE_STA, Callback_ConnectedToWiFi,
+                                   Callback_LostWiFiConnection );
+        if ( retval < 0 )
         {
-           Report("Failed to start SimpleLink Device\n\r", retval);
-           while( 1 )
-               ;
+            Report( "Failed to start SimpleLink Device\n\r", retval );
+            while ( 1 )
+                ;
         }
 
         /* Initialize AP security params                                          */
-        SlWlanSecParams_t securityParams = { 0 };
-        securityParams.Key = (signed char*)gApplicationControlBlock.desiredWifiKey;
-        securityParams.KeyLen = strlen(gApplicationControlBlock.desiredWifiKey);
-        securityParams.Type = gApplicationControlBlock.desiredWifiSecurityType;
+        SlWlanSecParams_t securityParams = {0};
+        securityParams.Key    = ( signed char* )gApplicationControlBlock.desiredWifiKey;
+        securityParams.KeyLen = strlen( gApplicationControlBlock.desiredWifiKey );
+        securityParams.Type   = gApplicationControlBlock.desiredWifiSecurityType;
 
-        Report("Attempting to connect to WiFi SSID: %s\n", gApplicationControlBlock.desiredWifiSSID);
-        Report("securityParams WiFi Type:    %d\n", securityParams.Type);
+        Report( "Attempting to connect to WiFi SSID: %s\n",
+                gApplicationControlBlock.desiredWifiSSID );
+        Report( "securityParams WiFi Type:    %d\n", securityParams.Type );
 
         /* Connect to the Access Point                                            */
-        retval = Network_IF_ConnectAP(gApplicationControlBlock.desiredWifiSSID, securityParams);
-        if (retval < 0)
+        retval = Network_IF_ConnectAP( gApplicationControlBlock.desiredWifiSSID,
+                                       securityParams );
+        if ( retval < 0 )
         {
-           Report("Connection to an AP failed\n\r");
-           Report( "Looping forever\n\r" );
-           while ( 1 )
-               ;
+            Report( "Connection to an AP failed\n\r" );
+            Report( "Looping forever\n\r" );
+            while ( 1 )
+                ;
         }
 
-        gApplicationControlBlock.initializationState = InitializationState_ConnectingToXively;
+        gApplicationControlBlock.initializationState =
+            InitializationState_ConnectingToXively;
 
         /* At this point the device has a wifi address. */
         /* Let's kick off our connection to Xively! */
@@ -408,7 +412,8 @@ void* xivelyExampleThread( void* arg )
         /* Wait for the Provisioning task to say that we have an IP address */
         if ( 0 > sem_wait( &gApplicationControlBlock.wifiConnectedSem ) )
         {
-            Report( "Semaphore returned error when waiting for Wifi Provisioning Task.\n\r" );
+            Report(
+                "Semaphore returned error when waiting for Wifi Provisioning Task.\n\r" );
             Report( "Looping forever\n\r" );
             while ( 1 )
                 ;
@@ -438,7 +443,8 @@ void Callback_ConnectedToWiFi()
 
 void Callback_LostWiFiConnection()
 {
-    gApplicationControlBlock.initializationState = InitializationState_ShuttingDownConnection;
+    gApplicationControlBlock.initializationState =
+        InitializationState_ShuttingDownConnection;
     Report( "Lost WiFi Connection.  Restarting Application!\n\r" );
     xi_shutdown_connection( gXivelyContextHandle );
 }
@@ -449,13 +455,12 @@ void Callback_LostWiFiConnection()
  */
 void ConnectToXively()
 {
-    Report(" Connecting to Xively: \n");
+    Report( " Connecting to Xively: \n" );
     Report( "\t- Xively Account ID: %s\n", gApplicationControlBlock.xivelyAccountId );
     Report( "\t- Xively Device ID: %s\n", gApplicationControlBlock.xivelyDeviceId );
     Report( "\t- Xively Device Password: <secret>\n" );
 
-    xi_state_t ret_state = xi_initialize( gApplicationControlBlock.xivelyAccountId,
-                                          gApplicationControlBlock.xivelyDeviceId );
+    xi_state_t ret_state = xi_initialize( gApplicationControlBlock.xivelyAccountId );
     if ( XI_STATE_OK != ret_state )
     {
         Report( "xi failed to initialize\n\r" );
@@ -466,8 +471,7 @@ void ConnectToXively()
 
     if ( XI_INVALID_CONTEXT_HANDLE == gXivelyContextHandle )
     {
-        Report( " xi failed to create context, error: %d\n\r",
-                    -gXivelyContextHandle );
+        Report( " xi failed to create context, error: %d\n\r", -gXivelyContextHandle );
         return;
     }
 #if ENABLE_XIVELY_FIRMWARE_UPDATE_AND_SECURE_FILE_TRANSFER
@@ -507,7 +511,7 @@ void exit_xi_and_cleanup()
  * */
 void on_connected( xi_context_handle_t in_context_handle, void* data, xi_state_t state )
 {
-    xi_connection_data_t* conn_data = ( xi_connection_data_t* )data;
+    xi_connection_data_t* conn_data                 = ( xi_connection_data_t* )data;
     gApplicationControlBlock.xivelyConnectionStatus = conn_data->connection_state;
     switch ( conn_data->connection_state )
     {
@@ -515,9 +519,11 @@ void on_connected( xi_context_handle_t in_context_handle, void* data, xi_state_t
             Report( "connection to %s:%d has failed reason %d\n\r", conn_data->host,
                     conn_data->port, state );
 
-            if( InitializationState_ShuttingDownConnection == gApplicationControlBlock.initializationState )
+            if ( InitializationState_ShuttingDownConnection ==
+                 gApplicationControlBlock.initializationState )
             {
-                Report( "on_connected callback noticed that the WiFi signal has been lost.  Shutting down.\n" );
+                Report( "on_connected callback noticed that the WiFi signal has been "
+                        "lost.  Shutting down.\n" );
                 exit_xi_and_cleanup();
                 return;
             }

--- a/examples/esp32/xively_demo/main/xively_task.c
+++ b/examples/esp32/xively_demo/main/xively_task.c
@@ -23,7 +23,7 @@
 #define XT_BUTTON_TOPIC_NAME "Button"
 #define XT_LED_TOPIC_NAME "LED"
 
-#define XT_CONNECT_TIMEOUT_S   10
+#define XT_CONNECT_TIMEOUT_S 10
 #define XT_KEEPALIVE_TIMEOUT_S 30
 
 #define INTERRUPT_POLLING_PERIOD 1
@@ -37,10 +37,7 @@ typedef struct
     char* xi_device_pwd;
 } xt_device_info_t;
 
-typedef enum {
-    XT_MQTT_DISCONNECTED = 0,
-    XT_MQTT_CONNECTED
-} xt_mqtt_connection_states_t;
+typedef enum { XT_MQTT_DISCONNECTED = 0, XT_MQTT_CONNECTED } xt_mqtt_connection_states_t;
 
 /******************************************************************************
  *                   Xively Task Function Declarations
@@ -63,9 +60,8 @@ static void xt_cancel_timed_tasks( void );
 static void xt_pop_gpio_interrupt_queue( void );
 
 /* Callbacks */
-static void xt_on_connected( xi_context_handle_t in_context_handle,
-                             void* data,
-                             xi_state_t state );
+static void
+xt_on_connected( xi_context_handle_t in_context_handle, void* data, xi_state_t state );
 static void xt_led_topic_callback( xi_context_handle_t in_context_handle,
                                    xi_sub_call_type_t call_type,
                                    const xi_sub_call_params_t* const params,
@@ -81,7 +77,7 @@ static xt_device_info_t xt_mqtt_device_info;
 xt_mqtt_topics_t xt_mqtt_topics;
 
 /* Xively Client Handles */
-static xi_context_handle_t xt_context_handle = -1;
+static xi_context_handle_t xt_context_handle                       = -1;
 static xi_timed_task_handle_t xt_gpiohandler_scheduled_task_handle = -1;
 
 /* FreeRTOS Handles */
@@ -119,8 +115,7 @@ void xt_rtos_task( void* param )
     assert( NULL != xt_mqtt_device_info.xi_device_id );
     assert( NULL != xt_mqtt_device_info.xi_device_pwd );
 
-    if ( XI_STATE_OK != xi_initialize( xt_mqtt_device_info.xi_account_id,
-                                       xt_mqtt_device_info.xi_device_id ) )
+    if ( XI_STATE_OK != xi_initialize( xt_mqtt_device_info.xi_account_id ) )
     {
         printf( "\n[XT] Failed to initialize MQTT library" );
         xt_handle_unrecoverable_error();
@@ -219,14 +214,14 @@ int8_t xt_build_xively_topic( char* topic_name, char* dst, uint32_t dst_len )
 {
     int retval = 0;
 
-    printf("\n[xt_build_xively_topic][topic_name: %s]", topic_name);
+    printf( "\n[xt_build_xively_topic][topic_name: %s]", topic_name );
     assert( NULL != topic_name );
     assert( NULL != dst );
 
     retval = snprintf( dst, dst_len, "xi/blue/v1/%.64s/d/%.64s/%.64s",
                        xt_mqtt_device_info.xi_account_id,
                        xt_mqtt_device_info.xi_device_id, topic_name );
-    printf("\n[xt_build_xively_topic][topic: %s]", dst);
+    printf( "\n[xt_build_xively_topic][topic: %s]", dst );
 
     if ( ( retval >= dst_len ) || ( retval < 0 ) )
     {
@@ -239,7 +234,7 @@ int8_t xt_init( char* xi_acc_id, char* xi_dev_id, char* xi_dev_pwd )
 {
     printf( "\n[XT] Initializing Xively Task variables" );
 
-    printf("\nsetting device variables");
+    printf( "\nsetting device variables" );
     xt_mqtt_device_info.xi_account_id = xi_acc_id;
     xt_mqtt_device_info.xi_device_id  = xi_dev_id;
     xt_mqtt_device_info.xi_device_pwd = xi_dev_pwd;
@@ -333,7 +328,7 @@ int8_t xt_subscribe( void )
 void xt_pop_gpio_interrupt_queue( void )
 {
     static int virtual_switch = 0; /* Switches between 1 and 0 on each button press */
-    char msg_payload[2] = "";
+    char msg_payload[2]       = "";
 
     if ( !xt_is_connected() )
     {
@@ -386,7 +381,8 @@ int8_t xt_start_timed_tasks( void )
         INTERRUPT_POLLING_PERIOD, 1, NULL );
     if ( XI_INVALID_TIMED_TASK_HANDLE == xt_gpiohandler_scheduled_task_handle )
     {
-        printf( "\n[XT] Error: GPIO interrupt polling scheduled task couldn't be registered" );
+        printf( "\n[XT] Error: GPIO interrupt polling scheduled task couldn't be "
+                "registered" );
         return -1;
     }
     printf( "\n[XT] GPIO interrupt polling scheduled task started" );
@@ -713,7 +709,7 @@ xt_action_requests_t xt_pop_highest_priority_request( void )
 inline void xt_await_unpause( void )
 {
     const TickType_t wait_timeout = portMAX_DELAY;
-    EventBits_t evt_group_bits = 0x00;
+    EventBits_t evt_group_bits    = 0x00;
     do /* Wait (forever) until either _CONTINUE or _SHUTDOWN are requested */
     {
         evt_group_bits = xEventGroupWaitBits( xt_requests_event_group_handle,

--- a/examples/firmware_update/src/firmware_update.c
+++ b/examples/firmware_update/src/firmware_update.c
@@ -227,7 +227,7 @@ int main( int argc, char* argv[] )
     /* initialize xi library and create a context to use to connect to the Xively Service
      * Device-id must be the same as username
      */
-    const xi_state_t error_init = xi_initialize( xi_account_id, xi_username );
+    const xi_state_t error_init = xi_initialize( xi_account_id );
 
     if ( XI_STATE_OK != error_init )
     {

--- a/examples/gateway/src/gateway.c
+++ b/examples/gateway/src/gateway.c
@@ -66,7 +66,7 @@ int main( int argc, char* argv[] )
     /* initialize xi library and create a context to use to connect to the Xively Service
      * Device-id must be the same as username
      */
-    const xi_state_t error_init = xi_initialize( xi_account_id, xi_username );
+    const xi_state_t error_init = xi_initialize( xi_account_id );
 
     if ( XI_STATE_OK != error_init )
     {

--- a/examples/mqtt_last_will/src/mqtt_last_will.c
+++ b/examples/mqtt_last_will/src/mqtt_last_will.c
@@ -159,7 +159,7 @@ int xi_mqtt_last_will_main( xi_embedded_args_t* xi_embedded_args )
     /* initialize xi library and create a context to use to connect to the Xively Service
      * Device-id must be the same as username
      */
-    const xi_state_t error_init = xi_initialize( xi_account_id, xi_username );
+    const xi_state_t error_init = xi_initialize( xi_account_id );
 
     if ( XI_STATE_OK != error_init )
     {

--- a/examples/mqtt_logic_consumer/src/mqtt_logic_consumer.c
+++ b/examples/mqtt_logic_consumer/src/mqtt_logic_consumer.c
@@ -120,7 +120,7 @@ int xi_mqtt_logic_consumer_main( xi_embedded_args_t* xi_embedded_args )
     /* initialize xi library and create a context to use to connect to the Xively Service
      * Device-id must be the same as username
      */
-    const xi_state_t error_init = xi_initialize( xi_account_id, xi_username );
+    const xi_state_t error_init = xi_initialize( xi_account_id );
 
     if ( XI_STATE_OK != error_init )
     {

--- a/examples/mqtt_logic_example/src/mqtt_logic_example.c
+++ b/examples/mqtt_logic_example/src/mqtt_logic_example.c
@@ -313,7 +313,7 @@ int xi_mqtt_logic_example_main( xi_embedded_args_t* xi_embedded_args )
     /* initialize xi library and create a context to use to connect to the Xively Service
      * Device-id must be the same as username
      */
-    const xi_state_t error_init = xi_initialize( xi_account_id, xi_username );
+    const xi_state_t error_init = xi_initialize( xi_account_id );
 
     if ( XI_STATE_OK != error_init )
     {

--- a/examples/mqtt_logic_example_two_contexts/src/mqtt_logic_example_two_contexts.c
+++ b/examples/mqtt_logic_example_two_contexts/src/mqtt_logic_example_two_contexts.c
@@ -245,7 +245,7 @@ int xi_mqtt_logic_example_two_contexts( xi_embedded_args_t* xi_embedded_args )
     /* initialize xi library and create a context to use to connect to the Xively Service
      * Device-id must be the same as username
      */
-    const xi_state_t error_init = xi_initialize( xi_account_id, xi_username );
+    const xi_state_t error_init = xi_initialize( xi_account_id );
 
     if ( XI_STATE_OK != error_init )
     {

--- a/examples/mqtt_logic_producer/src/mqtt_logic_producer.c
+++ b/examples/mqtt_logic_producer/src/mqtt_logic_producer.c
@@ -123,7 +123,7 @@ int xi_mqtt_logic_producer_main( xi_embedded_args_t* xi_embedded_args )
     /* initialize xi library and create a context to use to connect to the Xively Service
      * Device-id must be the same as username
      */
-    const xi_state_t error_init = xi_initialize( xi_account_id, xi_username );
+    const xi_state_t error_init = xi_initialize( xi_account_id );
 
     if ( XI_STATE_OK != error_init )
     {

--- a/examples/stm32/xively_demo_mt/Src/xively_client.c
+++ b/examples/stm32/xively_demo_mt/Src/xively_client.c
@@ -21,67 +21,66 @@
  *  Macros                                                                    *
  *                                                                            *
  ******************************************************************************/
-  /*
-   *  Application Specific
-   */
-#define  XC_STR_LEN              64
-#define  XC_CONNECT_TO            0 /* Seconds. Client/Broker connection wait time.   */
-#define  XC_KEEPALIVE_TO         10 /* Seconds. Client/Broker keep-alive period.      */
-#define  XC_CHECK_PERIOD          1 /* Seconds. Check period for publication changes. */
-#define  XC_MAX_PUBS_IN_FLIGHT    1
+/*
+ *  Application Specific
+ */
+#define XC_STR_LEN 64
+#define XC_CONNECT_TO 0    /* Seconds. Client/Broker connection wait time.   */
+#define XC_KEEPALIVE_TO 10 /* Seconds. Client/Broker keep-alive period.      */
+#define XC_CHECK_PERIOD 1  /* Seconds. Check period for publication changes. */
+#define XC_MAX_PUBS_IN_FLIGHT 1
 
-#define  XC_TASK_STACK          (512 * 6)
-#define  XC_TASK_NAME           ((signed char*)"XC Thread")
+#define XC_TASK_STACK ( 512 * 6 )
+#define XC_TASK_NAME ( ( signed char* )"XC Thread" )
 
-  /*
-   *  Device Specific
-   *  Credential Information
-   */
-#define  MS_DEVICE      0
-#define  BB_DEVICE      1
+/*
+ *  Device Specific
+ *  Credential Information
+ */
+#define MS_DEVICE 0
+#define BB_DEVICE 1
 
-#define  BUILD_DEVICE   BB_DEVICE
+#define BUILD_DEVICE BB_DEVICE
 
-#define  XC_ACCOUNT_ID   "bc4ebe58-b070-437b-9a64-a112bb2283d8"
+#define XC_ACCOUNT_ID "bc4ebe58-b070-437b-9a64-a112bb2283d8"
 
-  /*
-   *  Used by Morningstar
-   */
+/*
+ *  Used by Morningstar
+ */
 #if BUILD_DEVICE == MS_DEVICE
-  #define  XC_DEVICE_ID  "7da7df2a-6474-4444-bf5b-188abf383b0e"
-  #define  XC_PASSWORD   "+yvrZW+hKEU0xavmq+TB4sXHQCmXUXbqT4NHGv6bqwA="
+#define XC_DEVICE_ID "7da7df2a-6474-4444-bf5b-188abf383b0e"
+#define XC_PASSWORD "+yvrZW+hKEU0xavmq+TB4sXHQCmXUXbqT4NHGv6bqwA="
 
-  /*
-   *  Used by Bob Burke, Xively Professional Services
-   */
+/*
+ *  Used by Bob Burke, Xively Professional Services
+ */
 #elif BUILD_DEVICE == BB_DEVICE
-  #define  XC_DEVICE_ID  "63143c72-8037-482d-80cf-422c4e06ab1f"
-  #define  XC_PASSWORD   "mFOSQYbg0IP9SCCwJB+Oo1GKTBtYDQ921W+gf+sntq8="
+#define XC_DEVICE_ID "63143c72-8037-482d-80cf-422c4e06ab1f"
+#define XC_PASSWORD "mFOSQYbg0IP9SCCwJB+Oo1GKTBtYDQ921W+gf+sntq8="
 
 #else
-  #error Invalid "BUILD_DEVICE"
+#error Invalid "BUILD_DEVICE"
 #endif
 
 
+/*
+ *  Xively Specific
+ */
+#define XC_TOPIC_LEN 128
 
-  /*
-   *  Xively Specific
-   */
-#define  XC_TOPIC_LEN    128
-
-  /*
-   *  XC_TOPIC_FORMAT
-   *
-   *  snprintf format for fully qualified topic strings.
-   *    arg[0]: account_id
-   *    arg[1]: device_id
-   *    arg[2]: topic_name
-   */
-#define  XC_TOPIC_FORMAT  "xi/blue/v1/%s/d/%s/%s"
+/*
+ *  XC_TOPIC_FORMAT
+ *
+ *  snprintf format for fully qualified topic strings.
+ *    arg[0]: account_id
+ *    arg[1]: device_id
+ *    arg[2]: topic_name
+ */
+#define XC_TOPIC_FORMAT "xi/blue/v1/%s/d/%s/%s"
 
 
-#define  XC_NULL_CONTEXT   ((xi_context_handle_t)-1)
-#define  XC_NULL_T_HANDLE  ((xi_timed_task_handle_t)-1)
+#define XC_NULL_CONTEXT ( ( xi_context_handle_t )-1 )
+#define XC_NULL_T_HANDLE ( ( xi_timed_task_handle_t )-1 )
 
 
 /******************************************************************************
@@ -102,14 +101,20 @@
  *                                                                            *
  ******************************************************************************/
 
-/*                    TOPIC_ENUM,       TOPIC_NAME,      QOS,                       RETAIN     */
+/*                    TOPIC_ENUM,       TOPIC_NAME,      QOS,                       RETAIN
+ */
 
-#define XC_TOPIC_TABLE                                                                                     \
-  XC_TOPIC_PUB_ENTRY (BATTERY_VOLTAGE, "BatteryVoltage", XI_MQTT_QOS_AT_LEAST_ONCE, XI_MQTT_RETAIN_FALSE)  \
-  XC_TOPIC_PUB_ENTRY (PANEL_VOLTAGE,   "PanelVoltage",   XI_MQTT_QOS_AT_LEAST_ONCE, XI_MQTT_RETAIN_FALSE)  \
-  XC_TOPIC_PUB_ENTRY (CHARGE_CURRENT,  "ChargeCurrent",  XI_MQTT_QOS_AT_LEAST_ONCE, XI_MQTT_RETAIN_FALSE)  \
-  XC_TOPIC_PUB_ENTRY (STATUS_FLAGS,    "StatusFlags",    XI_MQTT_QOS_AT_LEAST_ONCE, XI_MQTT_RETAIN_FALSE)  \
-  XC_TOPIC_SUB_ENTRY (QUERY_ALL,       "QueryAll",       XI_MQTT_QOS_AT_LEAST_ONCE, XI_MQTT_RETAIN_FALSE)
+#define XC_TOPIC_TABLE                                                                   \
+    XC_TOPIC_PUB_ENTRY( BATTERY_VOLTAGE, "BatteryVoltage", XI_MQTT_QOS_AT_LEAST_ONCE,    \
+                        XI_MQTT_RETAIN_FALSE )                                           \
+    XC_TOPIC_PUB_ENTRY( PANEL_VOLTAGE, "PanelVoltage", XI_MQTT_QOS_AT_LEAST_ONCE,        \
+                        XI_MQTT_RETAIN_FALSE )                                           \
+    XC_TOPIC_PUB_ENTRY( CHARGE_CURRENT, "ChargeCurrent", XI_MQTT_QOS_AT_LEAST_ONCE,      \
+                        XI_MQTT_RETAIN_FALSE )                                           \
+    XC_TOPIC_PUB_ENTRY( STATUS_FLAGS, "StatusFlags", XI_MQTT_QOS_AT_LEAST_ONCE,          \
+                        XI_MQTT_RETAIN_FALSE )                                           \
+    XC_TOPIC_SUB_ENTRY( QUERY_ALL, "QueryAll", XI_MQTT_QOS_AT_LEAST_ONCE,                \
+                        XI_MQTT_RETAIN_FALSE )
 
 
 /******************************************************************************
@@ -118,12 +123,12 @@
  *                                                                            *
  ******************************************************************************/
 
-  /*
-   *  Subscribe callback function prototype.
-   */
-typedef xi_state_t (subscribe_cb_t)(const xi_context_handle_t ctx,
-                                    void *data,
-                                    xi_state_t state);
+/*
+ *  Subscribe callback function prototype.
+ */
+typedef xi_state_t( subscribe_cb_t )( const xi_context_handle_t ctx,
+                                      void* data,
+                                      xi_state_t state );
 
 
 /******************************************************************************
@@ -134,23 +139,19 @@ typedef xi_state_t (subscribe_cb_t)(const xi_context_handle_t ctx,
  *                                                                            *
  ******************************************************************************/
 
-#define XC_TOPIC_SUB_ENTRY(ENUM, NAME, QOS, RETAIN) \
-  ENUM,
+#define XC_TOPIC_SUB_ENTRY( ENUM, NAME, QOS, RETAIN ) ENUM,
 
-#define XC_TOPIC_PUB_ENTRY(ENUM, NAME, QOS, RETAIN) \
-  ENUM,
+#define XC_TOPIC_PUB_ENTRY( ENUM, NAME, QOS, RETAIN ) ENUM,
 
-typedef enum
-  {
-    XC_TOPIC_START   =  0,
+typedef enum {
+    XC_TOPIC_START   = 0,
     XC_TOPIC_INVALID = -1,
 
-      /* Invoke table macro */
-    XC_TOPIC_TABLE
-    XC_TOPIC_COUNT,
-    XC_PUB_START     = BATTERY_VOLTAGE,
-    XC_PUB_COUNT     = (STATUS_FLAGS - BATTERY_VOLTAGE + 1)
-  } xc_topic_e;
+    /* Invoke table macro */
+    XC_TOPIC_TABLE XC_TOPIC_COUNT,
+    XC_PUB_START = BATTERY_VOLTAGE,
+    XC_PUB_COUNT = ( STATUS_FLAGS - BATTERY_VOLTAGE + 1 )
+} xc_topic_e;
 
 
 #undef XC_TOPIC_SUB_ENTRY
@@ -181,12 +182,12 @@ typedef enum
  ******************************************************************************/
 
 typedef struct
-  {
-    char              *name;
-    xi_mqtt_qos_t     qos;
-    xi_mqtt_retain_t  retain;
-    subscribe_cb_t    *subscribe_cb;
-  } xc_topic_info_t;
+{
+    char* name;
+    xi_mqtt_qos_t qos;
+    xi_mqtt_retain_t retain;
+    subscribe_cb_t* subscribe_cb;
+} xc_topic_info_t;
 
 
 /******************************************************************************
@@ -195,17 +196,15 @@ typedef struct
  *                                                                            *
  ******************************************************************************/
 
-static void force_report      (void);
-static void xively_reset      (const xi_context_handle_t ctx);
-static void xc_subscribe_next (const xi_context_handle_t ctx);
+static void force_report( void );
+static void xively_reset( const xi_context_handle_t ctx );
+static void xc_subscribe_next( const xi_context_handle_t ctx );
 // static void check_report      (const xi_context_handle_t ctx);
 
-static xi_state_t
-subscribe_cb_common (
-  const xi_context_handle_t  ctx,
-  void                       *data,
-  xi_state_t                 state,
-  xc_topic_e                 topic_e);
+static xi_state_t subscribe_cb_common( const xi_context_handle_t ctx,
+                                       void* data,
+                                       xi_state_t state,
+                                       xc_topic_e topic_e );
 
 
 /******************************************************************************
@@ -214,16 +213,15 @@ subscribe_cb_common (
  *                                                                            *
  ******************************************************************************/
 
-#define XC_TOPIC_SUB_ENTRY(ENUM, NAME, QOS, RETAIN)                       \
-  static xi_state_t subscribe_cb_ ## ENUM (const xi_context_handle_t ctx, \
-                                           void *data,                    \
-                                           xi_state_t state);
+#define XC_TOPIC_SUB_ENTRY( ENUM, NAME, QOS, RETAIN )                                    \
+    static xi_state_t subscribe_cb_##ENUM( const xi_context_handle_t ctx, void* data,    \
+                                           xi_state_t state );
 
-  /* Empty */
-#define XC_TOPIC_PUB_ENTRY(ENUM, NAME, QOS, RETAIN)
+/* Empty */
+#define XC_TOPIC_PUB_ENTRY( ENUM, NAME, QOS, RETAIN )
 
 
-  /* Invoke table macro */
+/* Invoke table macro */
 XC_TOPIC_TABLE
 
 
@@ -239,28 +237,17 @@ XC_TOPIC_TABLE
  *                                                                            *
  ******************************************************************************/
 
-#define XC_TOPIC_SUB_ENTRY(ENUM, NAME, QOS, RETAIN)  \
-  {                                                  \
-    .name         = NAME,                            \
-    .qos          = QOS,                             \
-    .retain       = RETAIN,                          \
-    .subscribe_cb = subscribe_cb_ ## ENUM,           \
-  },
+#define XC_TOPIC_SUB_ENTRY( ENUM, NAME, QOS, RETAIN )                                    \
+    {                                                                                    \
+        .name = NAME, .qos = QOS, .retain = RETAIN, .subscribe_cb = subscribe_cb_##ENUM, \
+    },
 
-#define XC_TOPIC_PUB_ENTRY(ENUM, NAME, QOS, RETAIN)  \
-  {                                                  \
-    .name         = NAME,                            \
-    .qos          = QOS,                             \
-    .retain       = RETAIN,                          \
-    .subscribe_cb = NULL                             \
-  },
+#define XC_TOPIC_PUB_ENTRY( ENUM, NAME, QOS, RETAIN )                                    \
+    {.name = NAME, .qos = QOS, .retain = RETAIN, .subscribe_cb = NULL},
 
 
-  /* Invoke table macro */
-static xc_topic_info_t  xc_topic_info[] =
-  {
-    XC_TOPIC_TABLE
-  };
+/* Invoke table macro */
+static xc_topic_info_t xc_topic_info[] = {XC_TOPIC_TABLE};
 
 
 #undef XC_TOPIC_SUB_ENTRY
@@ -273,46 +260,46 @@ static xc_topic_info_t  xc_topic_info[] =
  *                                                                            *
  ******************************************************************************/
 
-  /*
-   *  web control
-   */
-int  xc_control;
+/*
+ *  web control
+ */
+int xc_control;
 
-  /*
-   *  Xively context handle
-   */
-static xi_context_handle_t  xc_ctx = XC_NULL_CONTEXT;
+/*
+ *  Xively context handle
+ */
+static xi_context_handle_t xc_ctx = XC_NULL_CONTEXT;
 
-  /*
-   *  Monitoring event handle
-   */
-static xi_timed_task_handle_t  monitor_cb_hdl = XC_NULL_T_HANDLE;
+/*
+ *  Monitoring event handle
+ */
+static xi_timed_task_handle_t monitor_cb_hdl = XC_NULL_T_HANDLE;
 
-  /*
-   *  Credential values
-   */
-static char  *account_id;
-static char  *device_id;
-static char  *password;
+/*
+ *  Credential values
+ */
+static char* account_id;
+static char* device_id;
+static char* password;
 
-  /*
-   *  Concurrent publication control
-   */
-static int  xc_pubs_in_flight = 0;
+/*
+ *  Concurrent publication control
+ */
+static int xc_pubs_in_flight = 0;
 
-  /*
-   *  Subscription control
-   */
+/*
+ *  Subscription control
+ */
 static xc_topic_e xc_subscribe_next_topic = XC_TOPIC_START;
 
 
-  /*
-   *  Data publication vars
-   */
-static int    poll_countdown;
-//static float  report_data[MS_VAL_COUNT];
-static int    report_flags;
-static int    report_pending[XC_PUB_COUNT];
+/*
+ *  Data publication vars
+ */
+static int poll_countdown;
+// static float  report_data[MS_VAL_COUNT];
+static int report_flags;
+static int report_pending[XC_PUB_COUNT];
 
 
 /******************************************************************************
@@ -322,17 +309,16 @@ static int    report_pending[XC_PUB_COUNT];
  *                                                                            *
  ******************************************************************************/
 
-#define XC_TOPIC_SUB_ENTRY(ENUM, NAME, QOS, RETAIN)                 \
-  static xi_state_t                                                 \
-  subscribe_cb_ ## ENUM (const xi_context_handle_t ctx, void *data, \
-                         xi_state_t state)                          \
-    {                                                               \
-      return subscribe_cb_common (ctx, data, state, ENUM);          \
+#define XC_TOPIC_SUB_ENTRY( ENUM, NAME, QOS, RETAIN )                                    \
+    static xi_state_t subscribe_cb_##ENUM( const xi_context_handle_t ctx, void* data,    \
+                                           xi_state_t state )                            \
+    {                                                                                    \
+        return subscribe_cb_common( ctx, data, state, ENUM );                            \
     }
 
-#define XC_TOPIC_PUB_ENTRY(ENUM, NAME, QOS, RETAIN) /* Empty */
+#define XC_TOPIC_PUB_ENTRY( ENUM, NAME, QOS, RETAIN ) /* Empty */
 
-  /* Invoke table macro */
+/* Invoke table macro */
 XC_TOPIC_TABLE
 
 #undef XC_TOPIC_SUB_ENTRY
@@ -348,42 +334,40 @@ XC_TOPIC_TABLE
  *                                                                            *
  ******************************************************************************/
 
-static xi_state_t
-subscribe_cb_common (
-  const xi_context_handle_t  ctx,
-  void                       *data,
-  xi_state_t                 state,
-  xc_topic_e                 topic_e)
-  {
-    xc_topic_info_t          *t_info = xc_topic_info + topic_e;
-    xi_mqtt_suback_status_t  status;
-    char                     *msg_ptr;
-    int                      msg_val;
-    xi_state_t               rval;
+static xi_state_t subscribe_cb_common( const xi_context_handle_t ctx,
+                                       void* data,
+                                       xi_state_t state,
+                                       xc_topic_e topic_e )
+{
+    xc_topic_info_t* t_info = xc_topic_info + topic_e;
+    xi_mqtt_suback_status_t status;
+    char* msg_ptr;
+    int msg_val;
+    xi_state_t rval;
 
-    (void)ctx;
+    ( void )ctx;
 
-    switch (state)
-      {
+    switch ( state )
+    {
         case XI_MQTT_SUBSCRIPTION_FAILED:
-          {
-            printf ("Xively: Subscribe failed \"%s\".\n", t_info->name);
+        {
+            printf( "Xively: Subscribe failed \"%s\".\n", t_info->name );
             rval = XI_STATE_OK;
-            xc_subscribe_next (ctx);  /* Subscribe to next topic */
+            xc_subscribe_next( ctx ); /* Subscribe to next topic */
             break;
-          }
+        }
 
         case XI_MQTT_SUBSCRIPTION_SUCCESSFULL:
-          {
-            status = (xi_mqtt_suback_status_t)(intptr_t)data;
-            printf ("Xively: Subscribe OK \"%s\", QoS %d\n", t_info->name, status );
+        {
+            status = ( xi_mqtt_suback_status_t )( intptr_t )data;
+            printf( "Xively: Subscribe OK \"%s\", QoS %d\n", t_info->name, status );
             rval = XI_STATE_OK;
-            xc_subscribe_next (ctx);  /* Subscribe to next topic */
+            xc_subscribe_next( ctx ); /* Subscribe to next topic */
             break;
-          }
+        }
 
         case XI_STATE_OK:
-          {
+        {
             rval = XI_STATE_OK;
 
 #if 0
@@ -426,15 +410,15 @@ subscribe_cb_common (
             xi_mqtt_message_free (&msg);
 #endif
             break;
-          }
+        }
 
         default:
-          rval = state;
-          break;
-      }
+            rval = state;
+            break;
+    }
 
     return rval;
-  }
+}
 
 
 /******************************************************************************
@@ -445,16 +429,15 @@ subscribe_cb_common (
  *                                                                            *
  ******************************************************************************/
 
-static void
-force_report (void)
-  {
-    xc_topic_e       e;
+static void force_report( void )
+{
+    xc_topic_e e;
 
-    for (e = XC_PUB_START; e < XC_PUB_COUNT; e ++)
-      {
+    for ( e = XC_PUB_START; e < XC_PUB_COUNT; e++ )
+    {
         report_pending[e] = 1;
-      }
-  }
+    }
+}
 
 
 /******************************************************************************
@@ -463,13 +446,11 @@ force_report (void)
  *                                                                            *
  ******************************************************************************/
 
-static void
-xively_reset (
-  const xi_context_handle_t ctx)
-  {
-    printf ("Xively: Reset\n");
-    xi_shutdown_connection (ctx);
-  }
+static void xively_reset( const xi_context_handle_t ctx )
+{
+    printf( "Xively: Reset\n" );
+    xi_shutdown_connection( ctx );
+}
 
 
 /******************************************************************************
@@ -479,33 +460,30 @@ xively_reset (
  ******************************************************************************/
 
 static xi_state_t
-publish_cb (
-  const xi_context_handle_t  ctx,
-  void*                      data,
-  xi_state_t                 state)
-  {
-    xc_topic_e             cb_topic;
-    const xc_topic_info_t  *t_info;
+publish_cb( const xi_context_handle_t ctx, void* data, xi_state_t state )
+{
+    xc_topic_e cb_topic;
+    const xc_topic_info_t* t_info;
 
-    (void)ctx;
+    ( void )ctx;
 
-    cb_topic = (xc_topic_e)((long)data);
-    t_info = xc_topic_info + cb_topic;
-    xc_pubs_in_flight --;
+    cb_topic = ( xc_topic_e )( ( long )data );
+    t_info   = xc_topic_info + cb_topic;
+    xc_pubs_in_flight--;
 
-    if (state == XI_STATE_OK)
-      {
-        printf ("Xively: Publish OK %s\n", t_info->name);
-      }
+    if ( state == XI_STATE_OK )
+    {
+        printf( "Xively: Publish OK %s\n", t_info->name );
+    }
     else
-      {
-        printf ("xively: Publish Error(%d) %s\n", state, t_info->name);
-      }
+    {
+        printf( "xively: Publish Error(%d) %s\n", state, t_info->name );
+    }
 
     // check_report (ctx);
 
     return XI_STATE_OK;
-  }
+}
 
 #if 0
 /******************************************************************************
@@ -644,32 +622,29 @@ check_values (void)
  ******************************************************************************/
 
 static void
-monitor_cb (
-  const xi_context_handle_t     ctx,
-  const xi_timed_task_handle_t  task,
-  void                          *data)
-  {
-    (void) task;
-    (void) data;
+monitor_cb( const xi_context_handle_t ctx, const xi_timed_task_handle_t task, void* data )
+{
+    ( void )task;
+    ( void )data;
 
     // check_values ();
     // check_report (ctx);
 
-    if (xc_control > 0)
-      {
-        if (xc_control == 1)
-          {
-            xively_reset (ctx);
-          }
+    if ( xc_control > 0 )
+    {
+        if ( xc_control == 1 )
+        {
+            xively_reset( ctx );
+        }
 
         xc_control = 0;
-      }
+    }
 
-      /*
-       *  Re-register "check_values" to be called in "XC_CHECK_PERIOD" seconds
-       */
-    monitor_cb_hdl = xi_schedule_timed_task (ctx, monitor_cb, XC_CHECK_PERIOD, 0, NULL);
-  }
+    /*
+     *  Re-register "check_values" to be called in "XC_CHECK_PERIOD" seconds
+     */
+    monitor_cb_hdl = xi_schedule_timed_task( ctx, monitor_cb, XC_CHECK_PERIOD, 0, NULL );
+}
 
 /******************************************************************************
  *                                                                            *
@@ -679,34 +654,32 @@ monitor_cb (
  *                                                                            *
  ******************************************************************************/
 
-static void
-xc_subscribe_next (
-  const xi_context_handle_t  ctx)
-  {
-    const xc_topic_info_t*  t_info;
-    char                    fq_topic[XC_TOPIC_LEN];
-    xc_topic_e              e;
+static void xc_subscribe_next( const xi_context_handle_t ctx )
+{
+    const xc_topic_info_t* t_info;
+    char fq_topic[XC_TOPIC_LEN];
+    xc_topic_e e;
 
-      /*
-       *  Subscribe to topics
-       */
-    for (e = xc_subscribe_next_topic; e < XC_TOPIC_COUNT; e ++)
-      {
+    /*
+     *  Subscribe to topics
+     */
+    for ( e = xc_subscribe_next_topic; e < XC_TOPIC_COUNT; e++ )
+    {
         t_info = xc_topic_info + e;
 
-        if (t_info->subscribe_cb)
-          {
-            snprintf (fq_topic, XC_TOPIC_LEN, XC_TOPIC_FORMAT,
-                      account_id, device_id, t_info->name);
+        if ( t_info->subscribe_cb )
+        {
+            snprintf( fq_topic, XC_TOPIC_LEN, XC_TOPIC_FORMAT, account_id, device_id,
+                      t_info->name );
 
-            printf ("Xively: Subscribe Pending \"%s\".\n", t_info->name);
-            xi_subscribe (ctx, fq_topic, t_info->qos, t_info->subscribe_cb, 0);
-            e ++;
+            printf( "Xively: Subscribe Pending \"%s\".\n", t_info->name );
+            xi_subscribe( ctx, fq_topic, t_info->qos, t_info->subscribe_cb, 0 );
+            e++;
             xc_subscribe_next_topic = e;
             break;
-          }
-      }
-  }
+        }
+    }
+}
 
 
 /******************************************************************************
@@ -718,74 +691,73 @@ xc_subscribe_next (
  ******************************************************************************/
 
 static xi_state_t
-connect_cb (
-  const xi_context_handle_t  ctx,
-  void                       *data,
-  xi_state_t                 state )
-  {
-    xi_connection_data_t  *conn_data = (xi_connection_data_t *)data;
-    xi_state_t            rval;
+connect_cb( const xi_context_handle_t ctx, void* data, xi_state_t state )
+{
+    xi_connection_data_t* conn_data = ( xi_connection_data_t* )data;
+    xi_state_t rval;
 
-    (void)ctx;
+    ( void )ctx;
 
-    switch (conn_data->connection_state)
-      {
-          /*
-           *  Connection attempt FAILED
-           */
+    switch ( conn_data->connection_state )
+    {
+        /*
+         *  Connection attempt FAILED
+         */
         case XI_CONNECTION_STATE_OPEN_FAILED:
-          {
-            printf("[%d] Xively: Connection failed to %s:%d, error %d\n", xi_bsp_time_getcurrenttime_seconds(),
-                    conn_data->host, conn_data->port, state );
+        {
+            printf( "[%d] Xively: Connection failed to %s:%d, error %d\n",
+                    xi_bsp_time_getcurrenttime_seconds(), conn_data->host,
+                    conn_data->port, state );
 
-            xi_connect (ctx,
-                        conn_data->username, conn_data->password,
-                        conn_data->connection_timeout,
-                        conn_data->keepalive_timeout,
-                        conn_data->session_type,
-                        &connect_cb);
+            xi_connect( ctx, conn_data->username, conn_data->password,
+                        conn_data->connection_timeout, conn_data->keepalive_timeout,
+                        conn_data->session_type, &connect_cb );
 
             rval = XI_STATE_OK;
             break;
-          }
+        }
 
 
-          /*
-           *  Preiviously open connection has CLOSED
-           */
+        /*
+         *  Preiviously open connection has CLOSED
+         */
         case XI_CONNECTION_STATE_CLOSED:
-          {
-            printf ("[%d] Xively: Connection closed, error %d\n", xi_bsp_time_getcurrenttime_seconds(), state);
+        {
+            printf( "[%d] Xively: Connection closed, error %d\n",
+                    xi_bsp_time_getcurrenttime_seconds(), state );
 
-              /* Connection closed */
-            xi_events_stop ();
+            /* Connection closed */
+            xi_events_stop();
 
             rval = XI_STATE_OK;
             break;
-          }
+        }
 
 
-          /*
-           *  New connection opened successfully
-           */
+        /*
+         *  New connection opened successfully
+         */
         case XI_CONNECTION_STATE_OPENED:
-          {
-            printf ("[%d] Xively: Connected %s:%d\n", xi_bsp_time_getcurrenttime_seconds(), conn_data->host, conn_data->port);
+        {
+            printf( "[%d] Xively: Connected %s:%d\n",
+                    xi_bsp_time_getcurrenttime_seconds(), conn_data->host,
+                    conn_data->port );
             rval = XI_STATE_OK;
             break;
-          }
+        }
 
 
         default:
-          {
-            printf ("[%d] Xively: Connection invalid, error %d\n", xi_bsp_time_getcurrenttime_seconds(), conn_data->connection_state );
+        {
+            printf( "[%d] Xively: Connection invalid, error %d\n",
+                    xi_bsp_time_getcurrenttime_seconds(), conn_data->connection_state );
             rval = XI_INVALID_PARAMETER;
             break;
-          }
-      }
+        }
+    }
 
     return rval;
-  }
+}
 
 /**
  * @brief Function that is required by TLS library to track the current time.
@@ -810,87 +782,86 @@ uint32_t xively_ssl_rand_generate()
  *                                                                            *
  ******************************************************************************/
 
-static int
-xc_main (void)
-  {
-    int         rval;
-    xi_state_t  xi_rc;
+static int xc_main( void )
+{
+    int rval;
+    xi_state_t xi_rc;
 
-      /*
-       * Set identity values
-       */
+    /*
+     * Set identity values
+     */
     device_id  = XC_DEVICE_ID;
     password   = XC_PASSWORD;
     account_id = XC_ACCOUNT_ID;
 
     rval = 0;
 
-    while (1)
-      {
-        printf ("Xively: ...continue.\n");
-//        test_alloc_report (-1);
+    while ( 1 )
+    {
+        printf( "Xively: ...continue.\n" );
+        //        test_alloc_report (-1);
 
-          /*
-           *  Initialize xively client library.
-           */
-        if ((xi_rc = xi_initialize(account_id, device_id )) == XI_STATE_OK)
-          {
-            if ((xc_ctx = xi_create_context()) < 0)
-              {
-                xi_rc = (xi_state_t)(0 - xc_ctx);
-                printf ("Xively: xi_create_context(): FATAL: RC: %d\n", xi_rc);
+        /*
+         *  Initialize xively client library.
+         */
+        if ( ( xi_rc = xi_initialize( account_id ) ) == XI_STATE_OK )
+        {
+            if ( ( xc_ctx = xi_create_context() ) < 0 )
+            {
+                xi_rc = ( xi_state_t )( 0 - xc_ctx );
+                printf( "Xively: xi_create_context(): FATAL: RC: %d\n", xi_rc );
                 rval = -1;
                 break;
-              }
-          }
+            }
+        }
         else
-          {
-            printf ("Xively: xi_initialize(): FATAL: RC: %d\n", xi_rc);
+        {
+            printf( "Xively: xi_initialize(): FATAL: RC: %d\n", xi_rc );
             rval = -1;
             break;
-          }
+        }
 
-          /*
-           *  Connect to the Xively broker.
-           *  "device_id" functions as the user name.
-           */
-        printf ("Xively: Connect pending\n");
-        printf (" deviceId \n  %s\n", device_id);
-        printf (" accountId\n  %s\n", account_id);
+        /*
+         *  Connect to the Xively broker.
+         *  "device_id" functions as the user name.
+         */
+        printf( "Xively: Connect pending\n" );
+        printf( " deviceId \n  %s\n", device_id );
+        printf( " accountId\n  %s\n", account_id );
 
 
-        xi_connect (xc_ctx, device_id, password, XC_CONNECT_TO,
-                    XC_KEEPALIVE_TO, XI_SESSION_CLEAN, &connect_cb);
+        xi_connect( xc_ctx, device_id, password, XC_CONNECT_TO, XC_KEEPALIVE_TO,
+                    XI_SESSION_CLEAN, &connect_cb );
 
-          /*  Loop forever */
-        xi_events_process_blocking ();
+        /*  Loop forever */
+        xi_events_process_blocking();
 
-        printf("Xively: Stopped\n");
+        printf( "Xively: Stopped\n" );
 
-        if (monitor_cb_hdl >= 0)
-          {
-            xi_cancel_timed_task (monitor_cb_hdl);
-          }
+        if ( monitor_cb_hdl >= 0 )
+        {
+            xi_cancel_timed_task( monitor_cb_hdl );
+        }
 
-        if ((xi_rc = xi_delete_context(xc_ctx)) != XI_STATE_OK)
-          {
-            printf ("Xively: xi_delete_context(): FATAL: XRC: %d\n", xi_rc);
-          }
+        if ( ( xi_rc = xi_delete_context( xc_ctx ) ) != XI_STATE_OK )
+        {
+            printf( "Xively: xi_delete_context(): FATAL: XRC: %d\n", xi_rc );
+        }
 
-        if ((xi_rc = xi_shutdown()) != XI_STATE_OK)
-          {
-            printf ("Xively: xi_shutdown(): FATAL: XRC: %d\n", xi_rc);
-          }
+        if ( ( xi_rc = xi_shutdown() ) != XI_STATE_OK )
+        {
+            printf( "Xively: xi_shutdown(): FATAL: XRC: %d\n", xi_rc );
+        }
 
         monitor_cb_hdl = XC_NULL_T_HANDLE;
-        xc_ctx = XC_NULL_CONTEXT;
+        xc_ctx         = XC_NULL_CONTEXT;
 
-        osDelay (1000); /* Pause for 1 second before attempting to reconnect */
-      }
+        osDelay( 1000 ); /* Pause for 1 second before attempting to reconnect */
+    }
 
-      /* We only get here on fatal error */
+    /* We only get here on fatal error */
     return rval;
-  }
+}
 
 
 /******************************************************************************
@@ -899,29 +870,27 @@ xc_main (void)
  *                                                                            *
  ******************************************************************************/
 
-static void
-xc_task (
-  void const*  args)
-  {
-    (void)args;
+static void xc_task( void const* args )
+{
+    ( void )args;
 
-    printf ("Xively: Pausing...\n");
+    printf( "Xively: Pausing...\n" );
 
-      /*
-       * Sleep for 10 seconds to let the network start
-       */
-    osDelay (2000);
+    /*
+     * Sleep for 10 seconds to let the network start
+     */
+    osDelay( 2000 );
 
-      /*
-       * Call the Xively "main" loop. This will never return.
-       */
-    xc_main ();
+    /*
+     * Call the Xively "main" loop. This will never return.
+     */
+    xc_main();
 
-    while (1)
-      {
-        osDelay (1000);
-      }
-  }
+    while ( 1 )
+    {
+        osDelay( 1000 );
+    }
+}
 
 
 /******************************************************************************
@@ -930,9 +899,8 @@ xc_task (
  *                                                                            *
  ******************************************************************************/
 
-void
-xively_client_start (void)
-  {
-    osThreadDef (XIVELY, xc_task, osPriorityNormal, 0, XC_TASK_STACK);
-    osThreadCreate (osThread(XIVELY), NULL);
-  }
+void xively_client_start( void )
+{
+    osThreadDef( XIVELY, xc_task, osPriorityNormal, 0, XC_TASK_STACK );
+    osThreadCreate( osThread( XIVELY ), NULL );
+}

--- a/examples/stm32/xively_demo_stm32f4xx_nucleo_eth/Src/xively_client.c
+++ b/examples/stm32/xively_demo_stm32f4xx_nucleo_eth/Src/xively_client.c
@@ -479,8 +479,7 @@ connect_cb( const xi_context_handle_t ctx, void* data, xi_state_t state )
         default:
         {
             printf( "[%ld] Xively: Connection invalid, error %d\n",
-                    xi_bsp_time_getcurrenttime_seconds(),
-                    conn_data->connection_state );
+                    xi_bsp_time_getcurrenttime_seconds(), conn_data->connection_state );
             rval = XI_INVALID_PARAMETER;
             break;
         }
@@ -554,13 +553,13 @@ static int xc_main( void )
     int rval;
     xi_state_t xi_rc;
 
-    /*
-     * Set identity values
-     */
+/*
+ * Set identity values
+ */
 #if USE_HARDCODED_CREDENTIALS
-    user_data_set_xi_account_id( (&user_config), USER_CONFIG_XI_ACCOUNT_ID );
-    user_data_set_xi_device_id( (&user_config), USER_CONFIG_XI_DEVICE_ID );
-    user_data_set_xi_device_password( (&user_config), USER_CONFIG_XI_DEVICE_PWD );
+    user_data_set_xi_account_id( ( &user_config ), USER_CONFIG_XI_ACCOUNT_ID );
+    user_data_set_xi_device_id( ( &user_config ), USER_CONFIG_XI_DEVICE_ID );
+    user_data_set_xi_device_password( ( &user_config ), USER_CONFIG_XI_DEVICE_PWD );
 #else
     if ( user_data_flash_init() < 0 )
     {
@@ -605,8 +604,7 @@ static int xc_main( void )
         /*
          *  Initialize xively client library.
          */
-        if ( XI_STATE_OK == ( xi_rc = xi_initialize( user_config.xi_account_id,
-                                                     user_config.xi_device_id ) ) )
+        if ( XI_STATE_OK == ( xi_rc = xi_initialize( user_config.xi_account_id ) ) )
         {
             if ( ( xc_ctx = xi_create_context() ) < 0 )
             {

--- a/examples/stm32/xively_demo_stm32f4xx_nucleo_wifi/Src/main.c
+++ b/examples/stm32/xively_demo_stm32f4xx_nucleo_wifi/Src/main.c
@@ -605,12 +605,12 @@ int main( void )
     }
 
 #if USE_HARDCODED_CREDENTIALS
-    user_data_set_wifi_ssid( (&user_config), USER_CONFIG_WIFI_SSID );
-    user_data_set_wifi_password( (&user_config), USER_CONFIG_WIFI_PWD );
-    user_data_set_wifi_encryption( (&user_config), USER_CONFIG_WIFI_ENCR );
-    user_data_set_xi_account_id( (&user_config), USER_CONFIG_XI_ACCOUNT_ID );
-    user_data_set_xi_device_id( (&user_config), USER_CONFIG_XI_DEVICE_ID );
-    user_data_set_xi_device_password( (&user_config), USER_CONFIG_XI_DEVICE_PWD );
+    user_data_set_wifi_ssid( ( &user_config ), USER_CONFIG_WIFI_SSID );
+    user_data_set_wifi_password( ( &user_config ), USER_CONFIG_WIFI_PWD );
+    user_data_set_wifi_encryption( ( &user_config ), USER_CONFIG_WIFI_ENCR );
+    user_data_set_xi_account_id( ( &user_config ), USER_CONFIG_XI_ACCOUNT_ID );
+    user_data_set_xi_device_id( ( &user_config ), USER_CONFIG_XI_DEVICE_ID );
+    user_data_set_xi_device_password( ( &user_config ), USER_CONFIG_XI_DEVICE_PWD );
 #else
     /* Read user data from flash */
     if ( user_data_copy_from_flash( &user_config ) < 0 )
@@ -700,13 +700,13 @@ int main( void )
                 printf( "\r\n\t* Account ID:  [%s]", user_config.xi_account_id );
                 printf( "\r\n\t* Device ID:   [%s]", user_config.xi_device_id );
                 printf( "\r\n\t* Device Pass: ( REDACTED )\n" );
-                // printf( "\r\n\t* Device Pass: [%s]\n", user_config.xi_device_password );
+                // printf( "\r\n\t* Device Pass: [%s]\n", user_config.xi_device_password
+                // );
 
                 if ( socket_open == 0 )
                 {
                     /* Read Write Socket data */
-                    xi_state_t ret_state = xi_initialize( user_config.xi_account_id,
-                                                          user_config.xi_device_id );
+                    xi_state_t ret_state = xi_initialize( user_config.xi_account_id );
                     if ( XI_STATE_OK != ret_state )
                     {
                         printf( "\r\n xi failed to initialise\n" );

--- a/include/xively.h
+++ b/include/xively.h
@@ -75,25 +75,17 @@ extern "C" {
 
 /**
  * @brief     Required before use of the xively library.
- * @detailed  This should be the first function that you call on a new runtime.  It
- * requires a string parameter that should be unique for the device the library is
- * running on ( serial number, etc. )  This is very important as otherwise messages
- * delivered by this device could be confused with other devices of the same unique
- * identifier.
+ * @detailed  This should be the first function that you call on a new runtime.
  *
- * Additionaly messages meant for other devices might be delivered to this
- * device if the device_unique_id is used across mulitple devices.
- *
- * @param [in] account_id A string that identifies the user's account in BluePrint.
- * @param [in] device_unique_id A string that represents this specific device.
+ * @param [in] account_id A string that identifies the user's account in Xively.
  *
  * @retval XI_STATE_OK              Status OK
  * @retval XI_FAILED_INITIALIZATION An urecoverable error occured
  * @retval XI_ALREADY_INITIALIZED   The runtime has previously invoked this
  * function succesfully.
- * @retval XI_INVALID_PARAMETER     If device_unique_id is null.
+ * @retval XI_INVALID_PARAMETER     If account_id is null.
  */
-extern xi_state_t xi_initialize( const char* account_id, const char* device_unique_id );
+extern xi_state_t xi_initialize( const char* account_id );
 
 /**
  * @brief     Signals the xively library to cleanup any internal memory
@@ -114,15 +106,6 @@ extern xi_state_t xi_initialize( const char* account_id, const char* device_uniq
  * @retval XI_FAILED_INITIALIZATION An urecoverable error occured
  */
 extern xi_state_t xi_shutdown();
-
-/**
- * @brief     Returns the device unique string that was passed to the xively
- * library during initialization.
- *
- * @retval NULL  If the system has not been succesfully initialized. Otherwise a
- * pointer to the device_unique_id.
- */
-extern const char* xi_get_device_unique_id();
 
 /**
  * @brief     Creates a connection context for subscriptions and publications

--- a/src/experimental/cc3200/xively_sft_external_client/main.c
+++ b/src/experimental/cc3200/xively_sft_external_client/main.c
@@ -250,8 +250,7 @@ void ConnectToXively()
     /* Disable the interrupt for now */
     Button_IF_DisableInterrupt( SW2 | SW3 );
 
-    xi_state_t ret_state = xi_initialize( g_wifi_device_credentials.xivelyAccountId,
-                                          g_wifi_device_credentials.xivelyDeviceId );
+    xi_state_t ret_state = xi_initialize( g_wifi_device_credentials.xivelyAccountId );
 
     if ( XI_STATE_OK != ret_state )
     {

--- a/src/libxively/xi_context.c
+++ b/src/libxively/xi_context.c
@@ -98,7 +98,7 @@ xi_state_t xi_create_context_with_custom_layers_and_evtd(
         return XI_INVALID_PARAMETER;
     }
 
-    if ( NULL == xi_globals.str_account_id || NULL == xi_globals.str_device_unique_id )
+    if ( NULL == xi_globals.str_account_id )
     {
         return XI_NOT_INITIALIZED;
     }

--- a/src/libxively/xi_globals.c
+++ b/src/libxively/xi_globals.c
@@ -15,6 +15,5 @@ xi_globals_t xi_globals = {
     .timed_tasks_container  = NULL,
     .main_threadpool        = NULL,
     .str_account_id         = NULL,
-    .str_device_unique_id   = NULL,
     .backoff_status = {xi_make_empty_time_event_handle(), 0, 0, XI_BACKOFF_CLASS_NONE, 0},
     .context_handles_vector_edge_devices = NULL};

--- a/src/libxively/xi_globals.h
+++ b/src/libxively/xi_globals.h
@@ -30,7 +30,6 @@ typedef struct
     xi_timed_task_container_t* timed_tasks_container;
     struct xi_threadpool_s* main_threadpool;
     char* str_account_id;
-    char* str_device_unique_id;
     xi_backoff_status_t backoff_status;
 
     xi_vector_t* context_handles_vector_edge_devices;

--- a/src/libxively/xively.c
+++ b/src/libxively/xively.c
@@ -125,24 +125,23 @@ xi_state_t check_csv_entry( const char* in_string, int* out_num_chars )
 /*
  * MAIN LIBRARY FUNCTIONS
  */
-xi_state_t xi_initialize( const char* account_id, const char* device_unique_id )
+xi_state_t xi_initialize( const char* account_id )
 {
     xi_bsp_time_init();
     xi_bsp_rng_init();
 
-    if ( NULL != xi_globals.str_account_id || NULL != xi_globals.str_device_unique_id )
+    if ( NULL != xi_globals.str_account_id )
     {
         return XI_ALREADY_INITIALIZED;
     }
-    else if ( NULL == account_id || NULL == device_unique_id )
+    else if ( NULL == account_id )
     {
         return XI_INVALID_PARAMETER;
     }
 
-    xi_globals.str_account_id       = xi_str_dup( account_id );
-    xi_globals.str_device_unique_id = xi_str_dup( device_unique_id );
+    xi_globals.str_account_id = xi_str_dup( account_id );
 
-    if ( NULL == xi_globals.str_device_unique_id || NULL == xi_globals.str_account_id )
+    if ( NULL == xi_globals.str_account_id )
     {
         return XI_FAILED_INITIALIZATION;
     }
@@ -153,40 +152,10 @@ xi_state_t xi_initialize( const char* account_id, const char* device_unique_id )
 xi_state_t xi_shutdown()
 {
     XI_SAFE_FREE( xi_globals.str_account_id );
-    XI_SAFE_FREE( xi_globals.str_device_unique_id );
 
     xi_bsp_rng_shutdown();
 
     return XI_STATE_OK;
-}
-
-xi_state_t xi_set_device_unique_id( const char* unique_id )
-{
-    if ( NULL == unique_id )
-    {
-        return XI_INVALID_PARAMETER;
-    }
-    else if ( NULL != xi_globals.str_device_unique_id )
-    {
-        return XI_ALREADY_INITIALIZED;
-    }
-
-    int len                         = strlen( unique_id );
-    xi_globals.str_device_unique_id = xi_alloc( len );
-
-    if ( NULL == xi_globals.str_device_unique_id )
-    {
-        return XI_OUT_OF_MEMORY;
-    }
-
-    strcpy( xi_globals.str_device_unique_id, unique_id );
-
-    return XI_STATE_OK;
-}
-
-const char* xi_get_device_id()
-{
-    return xi_globals.str_device_unique_id;
 }
 
 void xi_default_client_callback( xi_context_handle_t in_context_handle,

--- a/src/tests/itests/xi_itest_clean_session.c
+++ b/src/tests/itests/xi_itest_clean_session.c
@@ -140,7 +140,7 @@ int xi_itest_clean_session_setup( void** state )
 
     xi_memory_limiter_tearup();
 
-    assert_int_equal( XI_STATE_OK, xi_initialize( "itest-acc-id", "itest-dev-id" ) );
+    assert_int_equal( XI_STATE_OK, xi_initialize( "itest-acc-id" ) );
 
     XI_CHECK_STATE( xi_create_context_with_custom_layers_and_evtd(
         &xi_context, itest_cyassl_context, XI_LAYER_CHAIN_DEFAULT,

--- a/src/tests/itests/xi_itest_connect_error.c
+++ b/src/tests/itests/xi_itest_connect_error.c
@@ -104,8 +104,7 @@ int xi_itest_connect_error_setup( void** fixture_void )
     xi_globals.backoff_status.backoff_lut_i = 0;
     xi_cancel_backoff_event();
 
-    xi_initialize( "xi_itest_connect_error_account_id",
-                   "xi_itest_connect_error_device_id" );
+    xi_initialize( "xi_itest_connect_error_account_id" );
 
     XI_CHECK_STATE( xi_create_context_with_custom_layers_and_evtd(
         &xi_context, itest_ct_ml_mc_layer_chain, XI_LAYER_CHAIN_CT_ML_MC,

--- a/src/tests/itests/xi_itest_gateway.c
+++ b/src/tests/itests/xi_itest_gateway.c
@@ -73,7 +73,7 @@ int xi_itest_gateway_setup( void** fixture_void )
     xi_globals.backoff_status.backoff_lut_i = 0;
     xi_cancel_backoff_event();
 
-    xi_initialize( "xi_itest_gateway_account_id", "xi_itest_gateway_device_id" );
+    xi_initialize( "xi_itest_gateway_account_id" );
 
     xi_state_t state = xi_create_context_with_custom_layers_and_evtd(
         &fixture->xi_context_sut, itest_ct_ml_mc_layer_chain, XI_LAYER_CHAIN_CT_ML_MC,

--- a/src/tests/itests/xi_itest_mqttlogic_layer.c
+++ b/src/tests/itests/xi_itest_mqttlogic_layer.c
@@ -148,8 +148,7 @@ int xi_itest_mqttlogic_layer_setup( void** state )
 
     xi_memory_limiter_tearup();
 
-    assert_int_equal( XI_STATE_OK, xi_initialize( "xi_itest_tls_error_account_id",
-                                                  "xi_itest_tls_error_device_id" ) );
+    assert_int_equal( XI_STATE_OK, xi_initialize( "xi_itest_tls_error_account_id" ) );
 
     XI_CHECK_STATE( xi_create_context_with_custom_layers_and_evtd(
         &xi_context__itest_mqttlogic_layer, xi_itest_layer_chain_mqttlogic,

--- a/src/tests/itests/xi_itest_sft.c
+++ b/src/tests/itests/xi_itest_sft.c
@@ -155,7 +155,7 @@ int xi_itest_sft_setup( void** fixture_void )
     xi_globals.backoff_status.backoff_lut_i = 0;
     xi_cancel_backoff_event();
 
-    xi_initialize( "xi_itest_sft_account_id", "xi_itest_sft_device_id" );
+    xi_initialize( "xi_itest_sft_account_id" );
 
     XI_CHECK_STATE( xi_create_context_with_custom_layers_and_evtd(
         &xi_context, itest_ct_ml_mc_layer_chain, XI_LAYER_CHAIN_CT_ML_MC,

--- a/src/tests/itests/xi_itest_tls_error.c
+++ b/src/tests/itests/xi_itest_tls_error.c
@@ -125,7 +125,7 @@ int xi_itest_tls_error_setup( void** fixture_void )
     xi_globals.backoff_status.backoff_lut_i = 0;
     xi_cancel_backoff_event();
 
-    xi_initialize( "xi_itest_tls_error_account_id", "xi_itest_tls_error_device_id" );
+    xi_initialize( "xi_itest_tls_error_account_id" );
 
     XI_CHECK_STATE( xi_create_context_with_custom_layers_and_evtd(
         &xi_context, itest_ct_ml_mc_layer_chain, XI_LAYER_CHAIN_CT_ML_MC,

--- a/src/tests/itests/xi_itest_tls_layer.c
+++ b/src/tests/itests/xi_itest_tls_layer.c
@@ -57,8 +57,7 @@ int xi_itest_tls_layer_setup( void** fixture_void )
 
     *fixture_void = xi_itest_tls_layer__generate_fixture();
 
-    assert_int_equal( XI_STATE_OK, xi_initialize( "xi_itest_tls_error_account_id",
-                                                  "xi_itest_tls_error_device_id" ) );
+    assert_int_equal( XI_STATE_OK, xi_initialize( "xi_itest_tls_error_account_id" ) );
 
     XI_CHECK_STATE( xi_create_context_with_custom_layers_and_evtd(
         &xi_context__itest_tls_layer, itest_layer_chain_tls, XI_LAYER_CHAIN_TLS,

--- a/src/tests/tools/xi_libxively_driver/xi_libxively_driver.c
+++ b/src/tests/tools/xi_libxively_driver/xi_libxively_driver.c
@@ -135,7 +135,7 @@ int main( int argc, char const* argv[] )
     /*************************************
      * libxively initialization **********
      *************************************/
-    xi_initialize( "unique account id", "unique device id" );
+    xi_initialize( "unique account id" );
 
     xi_context_handle_t xi_app_context_handle = xi_create_context();
     if ( XI_INVALID_CONTEXT_HANDLE >= xi_app_context_handle )

--- a/src/tests/utests/xi_utest_basic_testcase_frame.c
+++ b/src/tests/utests/xi_utest_basic_testcase_frame.c
@@ -17,7 +17,7 @@ void* xi_utest_setup_basic( const struct testcase_t* testcase )
 
     xi_memory_limiter_tearup();
 
-    xi_initialize( "utest-account-id", "utest-device-id" );
+    xi_initialize( "utest-account-id" );
 
     return ( intptr_t* )1;
 }

--- a/src/tests/utests/xi_utest_control_topic.c
+++ b/src/tests/utests/xi_utest_control_topic.c
@@ -98,8 +98,7 @@ XI_TT_TESTCASE(
 
             if ( topic_names[i].device_id != NULL )
             {
-                tt_int_op( xi_initialize( "", topic_names[i].device_id ), ==,
-                           XI_STATE_OK );
+                tt_int_op( xi_initialize( "" ), ==, XI_STATE_OK );
             }
 
             xi_state_t state = xi_control_topic_create_topic_name(

--- a/src/tests/utests/xi_utest_core.c
+++ b/src/tests/utests/xi_utest_core.c
@@ -111,10 +111,10 @@ extern void xi_default_client_callback( xi_context_handle_t in_context_handle,
 XI_TT_TESTGROUP_BEGIN( utest_core )
 
 XI_TT_TESTCASE( test_initialize_shutdown_free_up_all_memory, {
-    xi_initialize( "test-acc", "test-dev" );
+    xi_initialize( "test-acc" );
     xi_shutdown();
 
-    xi_initialize( "test-acc", "test-dev" );
+    xi_initialize( "test-acc" );
     xi_shutdown();
 
     tt_want_int_op( xi_is_whole_memory_deallocated(), >, 0 );


### PR DESCRIPTION
[ Description ]
This PR contains a single parameter removal from the API function: `xi_initialize`. The device id is removed. Device id is already passed to `xi_connect` function. And is is misleading and error-prone to have two places to pass a single id.
Removing the parameter affects many-many files mainly examples (for all platforms) and tests.

[ JIRA ]
https://jira.ops.expertcity.com/browse/XCL-2939

[ Reviewer ]
@DellaBitta

[ QA ]
Local builds and all travis targets pass. Although not all platform's example application is built.

[ Release Notes ]
- API change: `xi_initialize` function parameters no longer require the device_id. `xi_connect` is the only place one has to pass device_id to the Xively C Client.