### PR TITLE
Feature/gateway fixes: various problems were solved found by Travis

### DIFF
--- a/src/libxively/control_topic/xi_control_topic_layer.c
+++ b/src/libxively/control_topic/xi_control_topic_layer.c
@@ -279,8 +279,6 @@ xi_control_topic_layer_push( void* context, void* data, xi_state_t in_out_state 
 {
     XI_LAYER_FUNCTION_PRINT_FUNCTION_DIGEST();
 
-    XI_UNUSED( data );
-
     return XI_PROCESS_PUSH_ON_PREV_LAYER( context, data, in_out_state );
 }
 

--- a/src/libxively/gateway/xi_gw_glue_layer.c
+++ b/src/libxively/gateway/xi_gw_glue_layer.c
@@ -9,6 +9,7 @@
 #include <xively_mqtt.h>
 #include <xively.h>
 #include <xi_types.h>
+#include <xively_api_impls.h>
 
 static void
 _xi_message_arrived_on_tunnel_callback( xi_context_handle_t in_context_handle,
@@ -54,9 +55,10 @@ xi_state_t xi_gw_glue_layer_init( void* context, void* data, xi_state_t in_out_s
     XI_LAYER_FUNCTION_PRINT_FUNCTION_DIGEST();
 
     /* subscribing main Xively Client to edge device specific tunnel topic */
-    xi_subscribe( XI_CONTEXT_DATA( context )->main_context_handle,
-                  "$Tunnel/tunnel-id-guid", XI_MQTT_QOS_AT_MOST_ONCE,
-                  _xi_message_arrived_on_tunnel_callback, context );
+    xi_subscribe_impl( XI_CONTEXT_DATA( context )->main_context_handle,
+                       "$Tunnel/tunnel-id-guid", XI_MQTT_QOS_AT_MOST_ONCE,
+                       _xi_message_arrived_on_tunnel_callback, context,
+                       XI_THREADID_MAINTHREAD );
 
     return XI_PROCESS_CONNECT_ON_THIS_LAYER( context, data, in_out_state );
 }
@@ -84,13 +86,10 @@ xi_state_t xi_gw_glue_layer_push( void* context, void* data, xi_state_t in_out_s
         xi_mqtt_retain_t shell_message_retain = 0;
 
         /* MQTT over MQTT, tunneling happens here. Publishing an MQTT encoded message. */
-        in_out_state =
-            xi_publish_data( XI_CONTEXT_DATA( context )->main_context_handle,
-                             "$Tunnel/tunnel-id-guid", mqtt_message_to_tunnel->data_ptr,
-                             mqtt_message_to_tunnel->length, shell_message_qos,
-                             shell_message_retain, _xi_publish_result_callback, context );
-
-        xi_free_desc( &mqtt_message_to_tunnel );
+        in_out_state = xi_publish_data_impl(
+            XI_CONTEXT_DATA( context )->main_context_handle, "$Tunnel/tunnel-id-guid",
+            mqtt_message_to_tunnel, shell_message_qos, shell_message_retain,
+            _xi_publish_result_callback, context, XI_THREADID_MAINTHREAD );
     }
     else if ( XI_STATE_WRITTEN == in_out_state )
     {

--- a/src/libxively/mqtt/codec/xi_mqtt_codec_layer.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_codec_layer.c
@@ -250,9 +250,6 @@ xi_state_t xi_mqtt_codec_layer_pull( void* context, void* data, xi_state_t in_ou
 {
     XI_LAYER_FUNCTION_PRINT_FUNCTION_DIGEST();
 
-    XI_UNUSED( data );
-    XI_UNUSED( in_out_state );
-
     xi_mqtt_codec_layer_data_t* layer_data =
         ( xi_mqtt_codec_layer_data_t* )XI_THIS_LAYER( context )->user_data;
 

--- a/src/libxively/platform/xi_thread/xi_thread_ids.h
+++ b/src/libxively/platform/xi_thread/xi_thread_ids.h
@@ -12,8 +12,7 @@
  *
  * With one of these IDs can one create event with a target thread.
  */
-enum
-{
+typedef enum xi_thread_id_e {
     /* specific thread IDs must start with 0, they specify position of thread
      * in main threadpool */
     XI_THREADID_THREAD_0 = 0,
@@ -22,6 +21,6 @@ enum
 
     XI_THREADID_ANYTHREAD = 250,
     XI_THREADID_MAINTHREAD
-};
+} xi_thread_id_t;
 
 #endif /* __XI_THREAD_IDS_H__ */

--- a/src/libxively/xively_api_impls.h
+++ b/src/libxively/xively_api_impls.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2003-2018, LogMeIn, Inc. All rights reserved.
+ *
+ * This is part of the Xively C Client library,
+ * it is licensed under the BSD 3-Clause license.
+ */
+
+#ifndef __XIVELY_API_IMPLS_H__
+#define __XIVELY_API_IMPLS_H__
+
+#include <xively_error.h>
+#include <xively_types.h>
+#include <xi_data_desc.h>
+#include <xi_thread_ids.h>
+
+xi_state_t xi_publish_data_impl( xi_context_handle_t xih,
+                                 const char* topic,
+                                 xi_data_desc_t* data,
+                                 const xi_mqtt_qos_t qos,
+                                 const xi_mqtt_retain_t retain,
+                                 xi_user_callback_t* callback,
+                                 void* user_data,
+                                 xi_thread_id_t callback_target_thread_id );
+
+xi_state_t xi_subscribe_impl( xi_context_handle_t xih,
+                              const char* topic,
+                              const xi_mqtt_qos_t qos,
+                              xi_user_subscription_callback_t* callback,
+                              void* user_data,
+                              xi_thread_id_t callback_target_thread_id );
+
+#endif /* __XIVELY_API_IMPLS_H__ */

--- a/src/tests/itests/tools/xi_itest_mock_broker_layer.c
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layer.c
@@ -189,8 +189,7 @@ xi_state_t xi_mock_broker_layer_pull( void* context, void* data, xi_state_t in_o
                 const char* publish_topic_name =
                     ( const char* )recvd_msg->publish.topic_name->data_ptr;
 
-                // printf( "--- %s --- PUBLISH (%s)\n", __FUNCTION__, publish_topic_name
-                // );
+                printf( "--- %s --- PUBLISH (%s)\n", __FUNCTION__, publish_topic_name );
 
                 xi_debug_format( "publish arrived on topic `%s`, msgid: %d",
                                  publish_topic_name, recvd_msg->publish.message_id );

--- a/src/tests/itests/tools/xi_itest_mock_broker_layer.h
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layer.h
@@ -24,13 +24,9 @@ typedef struct xi_mock_broker_data_s
     const char* control_topic_name_broker_in;
     const char* control_topic_name_broker_out;
 
-    xi_data_desc_t* outgoing_publish_content;
-    xi_data_desc_t* outgoing_publish_content_secondary_layer;
-
     /* two mock broker contexts (mock broker and the mock broker edge device handler)
      * alternate the execution between each other. This solves the MQTT over MQTT codec
      * (double MQTT encoding / decoding) */
-
     xi_layer_t* layer_tunneled_message_target;
     xi_layer_t* layer_output_target;
 

--- a/src/tests/itests/tools/xi_itest_mock_broker_sft_logic.c
+++ b/src/tests/itests/tools/xi_itest_mock_broker_sft_logic.c
@@ -241,8 +241,6 @@ xi_mock_broker_sft_logic_on_message( const xi_data_desc_t* control_message_encod
         {
             cbor_reply_message_data_desc = xi_make_desc_from_buffer_share(
                 cbor_reply_message, cbor_reply_message_len );
-            // todo_atigyi: make more elegant ownership passing
-            cbor_reply_message_data_desc->memory_type = XI_MEMORY_TYPE_MANAGED;
         }
         else
         {

--- a/src/tests/itests/xi_itest_tls_error.c
+++ b/src/tests/itests/xi_itest_tls_error.c
@@ -237,8 +237,9 @@ static void xi_itest_tls_error__act( void** fixture_void,
         if ( loop_counter == fixture->loop_id__control_topic_auto_subscribe )
         {
             xi_update_backoff_penalty( XI_STATE_OK );
-            state = xi_subscribe( xi_context_handle, fixture->control_topic_name,
-                                  XI_MQTT_QOS_AT_LEAST_ONCE, on_publish_received, NULL );
+
+            xi_subscribe( xi_context_handle, fixture->control_topic_name,
+                          XI_MQTT_QOS_AT_LEAST_ONCE, on_publish_received, NULL );
         }
 #endif
 

--- a/src/tests/itests/xi_itest_tls_error.c
+++ b/src/tests/itests/xi_itest_tls_error.c
@@ -638,7 +638,7 @@ void xi_itest_tls_error__tls_push_infinite_SUBSCRIBE_errors__reSUBSCRIBE_occurs_
              * that's why we have to increase this value by 2.*/
             const uint8_t expected_number_of_PUSHES =
                 fixture->loop_id__manual_disconnect -
-                fixture->loop_id__control_topic_auto_subscribe + 2;
+                fixture->loop_id__control_topic_auto_subscribe + 3;
 
             /* expecting only a certain number of message sends*/
             expect_value_count( xi_mock_broker_layer_push, in_out_state, XI_STATE_OK,


### PR DESCRIPTION
[ Description ]
This PR contains fixes of issues previous PR caused, these were:
- the gateway integration test failed in case threading module was turned on. This affected on libxively with gw and threading module both enabled.
- gcc compilation issues
- not stable gateway itest caused by usage of already deallocated memory.

These were solved by removing using separate thread for callbacks between the two internal layer chains: main layerchain and the edge device layerchain.
The gcc issue was a little bit more tricky: I had to remove not used include from the mock broker which resulted favourable simplification but also I had to adapt test cases to this mock broker change. 
The memory problem was solved by strict "object" lifetime eye-o-scopic pursuit :)

[ JIRA ]
https://jira.ops.expertcity.com/browse/XCL-2939

[ Reviewer ]
@DellaBitta

[ QA ]
All Travis targets and tests pass.

[ Release Notes ]
n/a