### PR TITLE
Adjusted current time with elapsed ticks

### DIFF
--- a/src/bsp/platform/stm32fx/xi_bsp_time_stm32fx.c
+++ b/src/bsp/platform/stm32fx/xi_bsp_time_stm32fx.c
@@ -13,17 +13,23 @@
 #endif
 #include <xi_bsp_time_stm32fx_sntp.h>
 
+static uint32_t ticks_at_start = 0;
+
 void xi_bsp_time_init()
 {
     xi_bsp_time_sntp_init( NULL );
+    if (xi_bsp_time_sntp_getseconds_posix() != 0)
+    {
+        ticks_at_start = HAL_GetTick();
+    }
 }
 
 xi_time_t xi_bsp_time_getcurrenttime_seconds()
 {
-    return xi_bsp_time_sntp_getseconds_posix() + HAL_GetTick() / 1000;
+    return xi_bsp_time_sntp_getseconds_posix() + (HAL_GetTick()-ticks_at_start) / 1000;
 }
 
 xi_time_t xi_bsp_time_getcurrenttime_milliseconds()
 {
-    return xi_bsp_time_sntp_getseconds_posix() + HAL_GetTick() / 1000;
+    return xi_bsp_time_sntp_getseconds_posix() + (HAL_GetTick()-ticks_at_start) / 1000;
 }


### PR DESCRIPTION
The fix is calculating in the elapsed ticks at the init time to remove the problematic offset.
Details:
The HAL tick counter is reflecting the elapsed time since the startup of the MCU. When the xi_bsp_time_init() is called the tick counter is already containing the elapsed time (it is non-zero). This distorts the result of the xi_bsp_time_getcurrenttime_seconds() function as a problematic offset will appear. This is even more significant in case the xi_bsp_time_init() is called repeatedly or with a delay. 