### PR TITLE
IO NET layer robustness

### DIFF
--- a/include/bsp/xi_bsp_io_net.h
+++ b/include/bsp/xi_bsp_io_net.h
@@ -276,7 +276,8 @@ xi_bsp_io_net_connection_check( xi_bsp_socket_t xi_socket_nonblocking,
  * perform any other actions.
  *
  * @param [in] xi_socket_nonblocking data is sent on this socket
- * @param [out] out_written_count upon return this should contain the number of sent bytes
+ * @param [out] out_written_count upon return this should contain the number of sent
+ *                                bytes. Negative value may cause connection close.
  * @param [in] buf the data to send
  * @param [in] count number of bytes to send from the buffer. This is the size of
  *                   the buffer.

--- a/include/bsp/xi_bsp_io_net.h
+++ b/include/bsp/xi_bsp_io_net.h
@@ -277,7 +277,7 @@ xi_bsp_io_net_connection_check( xi_bsp_socket_t xi_socket_nonblocking,
  *
  * @param [in] xi_socket_nonblocking data is sent on this socket
  * @param [out] out_written_count upon return this should contain the number of sent
- *                                bytes. Negative value may cause connection close.
+ *                                bytes. Negative value causes connection close.
  * @param [in] buf the data to send
  * @param [in] count number of bytes to send from the buffer. This is the size of
  *                   the buffer.

--- a/src/bsp/platform/esp32/xi_esp32_bsp_component/xi_bsp_io_net_esp32.c
+++ b/src/bsp/platform/esp32/xi_esp32_bsp_component/xi_bsp_io_net_esp32.c
@@ -42,7 +42,7 @@ xi_bsp_io_net_state_t
 xi_bsp_io_net_connect( xi_bsp_socket_t* xi_socket, const char* host, uint16_t port )
 {
     struct hostent* hostinfo = gethostbyname( host );
-    int errno_cpy = 0; /* errno is reset every time it's read */
+    int errno_cpy            = 0; /* errno is reset every time it's read */
 
     /* if null it means that the address has not been found */
     if ( NULL == hostinfo )
@@ -127,8 +127,10 @@ xi_bsp_io_net_state_t xi_bsp_io_net_write( xi_bsp_socket_t xi_socket,
 
     *out_written_count = write( xi_socket, buf, count );
 
-    if ( 0 > *out_written_count )
+    if ( *out_written_count < 0 )
     {
+        *out_written_count = 0;
+
         errval = errno;
 
         if ( EAGAIN == errval )
@@ -140,6 +142,8 @@ xi_bsp_io_net_state_t xi_bsp_io_net_write( xi_bsp_socket_t xi_socket,
         {
             return XI_BSP_IO_NET_STATE_CONNECTION_RESET;
         }
+
+        return XI_BSP_IO_NET_STATE_ERROR;
     }
 
     return XI_BSP_IO_NET_STATE_OK;
@@ -158,8 +162,10 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
     int errval      = 0;
     *out_read_count = read( xi_socket, buf, count );
 
-    if ( 0 > *out_read_count )
+    if ( *out_read_count < 0 )
     {
+        *out_read_count = 0;
+
         errval = errno;
 
         if ( EAGAIN == errval )
@@ -171,6 +177,8 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
         {
             return XI_BSP_IO_NET_STATE_CONNECTION_RESET;
         }
+
+        return XI_BSP_IO_NET_STATE_ERROR;
     }
 
     if ( 0 == *out_read_count )

--- a/src/bsp/platform/posix/xi_bsp_io_net_posix.c
+++ b/src/bsp/platform/posix/xi_bsp_io_net_posix.c
@@ -126,8 +126,10 @@ xi_bsp_io_net_state_t xi_bsp_io_net_write( xi_bsp_socket_t xi_socket,
 
     *out_written_count = write( xi_socket, buf, count );
 
-    if ( 0 > *out_written_count )
+    if ( *out_written_count < 0 )
     {
+        *out_written_count = 0;
+
         errval = errno;
         errno  = 0;
 
@@ -140,6 +142,8 @@ xi_bsp_io_net_state_t xi_bsp_io_net_write( xi_bsp_socket_t xi_socket,
         {
             return XI_BSP_IO_NET_STATE_CONNECTION_RESET;
         }
+
+        return XI_BSP_IO_NET_STATE_ERROR;
     }
 
     return XI_BSP_IO_NET_STATE_OK;
@@ -158,8 +162,10 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
     int errval      = 0;
     *out_read_count = read( xi_socket, buf, count );
 
-    if ( 0 > *out_read_count )
+    if ( *out_read_count < 0 )
     {
+        *out_read_count = 0;
+
         errval = errno;
         errno  = 0;
 
@@ -172,6 +178,8 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
         {
             return XI_BSP_IO_NET_STATE_CONNECTION_RESET;
         }
+
+        return XI_BSP_IO_NET_STATE_ERROR;
     }
 
     if ( 0 == *out_read_count )

--- a/src/bsp/platform/stm32fx/xi_bsp_io_net_stm32fx.c
+++ b/src/bsp/platform/stm32fx/xi_bsp_io_net_stm32fx.c
@@ -43,7 +43,7 @@ xi_bsp_io_net_state_t
 xi_bsp_io_net_connect( xi_bsp_socket_t* xi_socket, const char* host, uint16_t port )
 {
     struct hostent* hostinfo = gethostbyname( host );
-    int errno_cpy = 0; /* errno is reset every time it's read */
+    int errno_cpy            = 0; /* errno is reset every time it's read */
 
     /* if null it means that the address has not been found */
     if ( NULL == hostinfo )
@@ -131,8 +131,10 @@ xi_bsp_io_net_state_t xi_bsp_io_net_write( xi_bsp_socket_t xi_socket,
 
     *out_written_count = write( xi_socket, buf, count );
 
-    if ( 0 > *out_written_count )
+    if ( *out_written_count < 0 )
     {
+        *out_written_count = 0;
+
         errval = errno;
         errno  = 0;
 
@@ -145,6 +147,8 @@ xi_bsp_io_net_state_t xi_bsp_io_net_write( xi_bsp_socket_t xi_socket,
         {
             return XI_BSP_IO_NET_STATE_CONNECTION_RESET;
         }
+
+        return XI_BSP_IO_NET_STATE_ERROR;
     }
 
     return XI_BSP_IO_NET_STATE_OK;
@@ -163,8 +167,10 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
     int errval      = 0;
     *out_read_count = read( xi_socket, buf, count );
 
-    if ( 0 > *out_read_count )
+    if ( *out_read_count < 0 )
     {
+        *out_read_count = 0;
+
         errval = errno;
         errno  = 0;
 
@@ -177,6 +183,8 @@ xi_bsp_io_net_state_t xi_bsp_io_net_read( xi_bsp_socket_t xi_socket,
         {
             return XI_BSP_IO_NET_STATE_CONNECTION_RESET;
         }
+
+        return XI_BSP_IO_NET_STATE_ERROR;
     }
 
     if ( 0 == *out_read_count )

--- a/src/libxively/io/net/xi_io_net_layer.c
+++ b/src/libxively/io/net/xi_io_net_layer.c
@@ -165,7 +165,7 @@ xi_state_t xi_io_net_layer_push( void* context, void* data, xi_state_t in_out_st
                                              buffer->capacity - buffer->curr_pos );
 
             /* verify the state if it's an error or a need to wait */
-            if ( XI_BSP_IO_NET_STATE_OK != bsp_state )
+            if ( XI_BSP_IO_NET_STATE_OK != bsp_state || len < 0 )
             {
                 if ( XI_BSP_IO_NET_STATE_BUSY ==
                      bsp_state ) /* that can happen in asynch environments */
@@ -199,8 +199,8 @@ xi_state_t xi_io_net_layer_push( void* context, void* data, xi_state_t in_out_st
                 else
                 {
                     /* any other issue */
-                    xi_debug_format( "error writing: BSP error code = %d\n",
-                                     ( int )bsp_state );
+                    xi_debug_format( "error writing: BSP error code = %d, len = %d\n",
+                                     ( int )bsp_state, len );
                     xi_free_desc( &buffer );
                     return XI_PROCESS_CLOSE_EXTERNALLY_ON_THIS_LAYER(
                         context, data, XI_SOCKET_WRITE_ERROR );


### PR DESCRIPTION
[ Description ]
Increasing fault tolerance of the IO NET layer against the `xi_bsp_io_net_write` function: handling return value `XI_BSP_IO_NET_STATE_OK` with negative length bytes written. The client library will close connection when the socket write failure occurred. This is the same error handling happening with any other error during socket write.

[ JIRA ]
n/a

[ Reviewer ]
@DellaBitta

[ QA ]
All auto tests: unit, integration and the functional tests pass.

[ Release Notes ]
ESP32 and POSIX Reference BSPs now always return error codes to the Xively C Client Library for negative values retunred from networking read() and write() operations.