### PR TITLE
Fixes for case statement fallthroughs, which Debian gcc version 7.3.…

### DIFF
--- a/src/import/cn-cbor/src/cn-get.c
+++ b/src/import/cn-cbor/src/cn-get.c
@@ -20,6 +20,7 @@ cn_cbor* cn_cbor_mapget_int(const cn_cbor* cb, int key) {
       if (cp->v.uint == (unsigned long)key) {
         return cp->next;
       }
+      break;
     case CN_CBOR_INT:
       if (cp->v.sint == (long)key) {
         return cp->next;

--- a/src/libxively/control_topic/xi_control_topic_layer.c
+++ b/src/libxively/control_topic/xi_control_topic_layer.c
@@ -196,6 +196,7 @@ xi_state_t xi_on_control_message( xi_context_handle_t in_context_handle,
                 xi_sft_on_connected( layer_data->sft_context );
 #endif
             }
+            break;
         }
         case XI_SUB_CALL_MESSAGE:
         {
@@ -212,6 +213,7 @@ xi_state_t xi_on_control_message( xi_context_handle_t in_context_handle,
 
             xi_sft_on_message( layer_data->sft_context, control_message );
 #endif
+            break;
         }
 
         default:;

--- a/src/libxively/xi_backoff_status_api.c
+++ b/src/libxively/xi_backoff_status_api.c
@@ -95,8 +95,6 @@ void xi_cancel_backoff_event()
 void xi_reset_backoff_penalty()
 {
     xi_globals.backoff_status.backoff_lut_i = 0;
-    xi_globals.backoff_status.decay_lut_i   = 0;
-
     xi_cancel_backoff_event();
 }
 #endif

--- a/src/libxively/xi_backoff_status_api.c
+++ b/src/libxively/xi_backoff_status_api.c
@@ -95,6 +95,8 @@ void xi_cancel_backoff_event()
 void xi_reset_backoff_penalty()
 {
     xi_globals.backoff_status.backoff_lut_i = 0;
+    xi_globals.backoff_status.decay_lut_i   = 0;
+    
     xi_cancel_backoff_event();
 }
 #endif


### PR DESCRIPTION
[ Description ]
I ran into some warnings thrown as errors when compiling on a fresh Ubuntu machine.  The warnings were about case statements automatically falling through. I've added break statements to fix these issue, tracing to code to ensure that the fallthrough wasn't intended in the first place.

[ Reviewer ]
@atigyi 

[ QA ]
Built running make and the mbedTLS implementation.  WolfSSL seems to have issues building on this development machine due to similar toolchain warnings-as-errors.

[ Release Notes ]
Fixes for building the xively-c-client with Debian GCC version 7.3.0 which produced some case statement fallthrough warnings.