### PR TITLE
Fix on KeepAlive Ping Write Errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,3 +100,4 @@ script:
         fi;
     fi;"
 
+

--- a/doc/doxygen/build.sh
+++ b/doc/doxygen/build.sh
@@ -5,3 +5,4 @@ cd ../api
 rm -rf output
 doxygen doxygen.config
 cd ..
+

--- a/doc/doxygen/build.sh
+++ b/doc/doxygen/build.sh
@@ -5,4 +5,3 @@ cd ../api
 rm -rf output
 doxygen doxygen.config
 cd ..
-

--- a/src/libxively/mqtt/codec/xi_mqtt_parser.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_parser.c
@@ -485,6 +485,11 @@ xi_state_t xi_mqtt_parser_execute( xi_mqtt_parser_t* parser,
 
         XI_CR_EXIT( parser->cs, XI_STATE_OK );
     }
+    else if ( message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGREQ )
+    {
+        /* nothing to parse */
+        XI_CR_EXIT( parser->cs, XI_STATE_OK );
+    }
     else if ( message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGRESP )
     {
         /* nothing to parse */

--- a/src/libxively/mqtt/codec/xi_mqtt_parser.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_parser.c
@@ -485,12 +485,8 @@ xi_state_t xi_mqtt_parser_execute( xi_mqtt_parser_t* parser,
 
         XI_CR_EXIT( parser->cs, XI_STATE_OK );
     }
-    else if ( message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGREQ )
-    {
-        /* nothing to parse */
-        XI_CR_EXIT( parser->cs, XI_STATE_OK );
-    }
-    else if ( message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGRESP )
+    else if ( message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGREQ ||
+              message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGRESP )
     {
         /* nothing to parse */
         XI_CR_EXIT( parser->cs, XI_STATE_OK );

--- a/src/libxively/mqtt/codec/xi_mqtt_serialiser.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_serialiser.c
@@ -162,6 +162,10 @@ xi_state_t xi_mqtt_serialiser_size( size_t* msg_len,
     {
         /* just a fixed header */
     }
+    else if ( message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGRESP )
+    {
+        /* just a fixed header */
+    }
     else
     {
         return XI_MQTT_SERIALIZER_ERROR;
@@ -300,6 +304,7 @@ xi_mqtt_serialiser_rc_t xi_mqtt_serialiser_write( xi_mqtt_serialiser_t* serialis
         }
 
         case XI_MQTT_TYPE_PINGREQ:
+        case XI_MQTT_TYPE_PINGRESP:
         {
             /* empty */
             break;

--- a/src/libxively/mqtt/codec/xi_mqtt_serialiser.c
+++ b/src/libxively/mqtt/codec/xi_mqtt_serialiser.c
@@ -158,11 +158,8 @@ xi_state_t xi_mqtt_serialiser_size( size_t* msg_len,
         *msg_len += 2; /* size of the msg id */
         *msg_len += 1; /* qos */
     }
-    else if ( message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGREQ )
-    {
-        /* just a fixed header */
-    }
-    else if ( message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGRESP )
+    else if ( message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGREQ ||
+              message->common.common_u.common_bits.type == XI_MQTT_TYPE_PINGRESP )
     {
         /* just a fixed header */
     }

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer.c
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer.c
@@ -605,6 +605,11 @@ xi_mqtt_logic_layer_close_externally( void* context, void* data, xi_state_t in_o
     /* let's stop the current task */
     if ( layer_data->current_q0_task != 0 )
     {
+        if ( NULL != layer_data->current_q0_task->timeout.ptr_to_position )
+        {
+            xi_evtd_cancel( event_dispatcher, &layer_data->current_q0_task->timeout );
+        }
+
         layer_data->current_q0_task->logic.handlers.h4.a3 = XI_STATE_TIMEOUT;
         xi_evtd_execute_handle( &layer_data->current_q0_task->logic );
         xi_mqtt_logic_free_task( &layer_data->current_q0_task );

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_keepalive_handler.c
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_keepalive_handler.c
@@ -82,6 +82,7 @@ do_mqtt_keepalive_task( void* ctx, void* data, xi_state_t state, void* msg_data 
     else
     {
         xi_debug_format( "pingreq message has not been sent... %d", ( int )state );
+        XI_CHECK_STATE( state );
     }
 
     // wait for an interval of keepalive

--- a/src/libxively/mqtt/logic/xi_mqtt_logic_layer_keepalive_handler.c
+++ b/src/libxively/mqtt/logic/xi_mqtt_logic_layer_keepalive_handler.c
@@ -82,7 +82,6 @@ do_mqtt_keepalive_task( void* ctx, void* data, xi_state_t state, void* msg_data 
     else
     {
         xi_debug_format( "pingreq message has not been sent... %d", ( int )state );
-        XI_CHECK_STATE( state );
     }
 
     // wait for an interval of keepalive

--- a/src/tests/itests/tools/xi_itest_mock_broker_layer.c
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layer.c
@@ -133,8 +133,6 @@ xi_state_t xi_mock_broker_layer_pull( void* context, void* data, xi_state_t in_o
         XI_CONNACK_REFUSED_NOT_AUTHORIZED        = 5
     };
 
-    printf("helloka\n");
-
     XI_MOCK_BROKER_CONDITIONAL__CHECK_EXPECTED( in_out_state, LAYER_LEVEL );
 
     xi_layer_t* layer                 = ( xi_layer_t* )XI_THIS_LAYER( context );
@@ -150,7 +148,7 @@ xi_state_t xi_mock_broker_layer_pull( void* context, void* data, xi_state_t in_o
         // const uint16_t msg_id = xi_mqtt_get_message_id( recvd_msg );
         const xi_mqtt_type_t recvd_msg_type = recvd_msg->common.common_u.common_bits.type;
 
-        xi_debug_format( "mock broker received message with type %d\n", recvd_msg_type );
+        xi_debug_format( "mock broker received message with type %d", recvd_msg_type );
 
         XI_MOCK_BROKER_CONDITIONAL__CHECK_EXPECTED( recvd_msg_type, MQTT_LEVEL );
 

--- a/src/tests/itests/tools/xi_itest_mock_broker_layer.c
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layer.c
@@ -256,13 +256,18 @@ xi_state_t xi_mock_broker_layer_pull( void* context, void* data, xi_state_t in_o
 
             case XI_MQTT_TYPE_PINGREQ:
                 {
-                    XI_ALLOC( xi_mqtt_message_t, mqtt_pingresp, in_out_state );
-                    memcpy( mqtt_pingresp, recvd_msg, sizeof( xi_mqtt_message_t ) );
+                    const xi_mock_broker_control_t control = mock_type( xi_mock_broker_control_t );
 
-                    mqtt_pingresp->common.common_u.common_bits.type = XI_MQTT_TYPE_PINGRESP;
+                    if ( CONTROL_PULL_PINGREQ_SUPPRESS_RESPONSE != control )
+                    {
+                        XI_ALLOC( xi_mqtt_message_t, mqtt_pingresp, in_out_state );
+                        memcpy( mqtt_pingresp, recvd_msg, sizeof( xi_mqtt_message_t ) );
 
-                    in_out_state = XI_PROCESS_PUSH_ON_PREV_LAYER(
-                                          context, mqtt_pingresp, in_out_state );
+                        mqtt_pingresp->common.common_u.common_bits.type = XI_MQTT_TYPE_PINGRESP;
+
+                        in_out_state = XI_PROCESS_PUSH_ON_PREV_LAYER(
+                                              context, mqtt_pingresp, in_out_state );
+                    }
                 }
             break;
 

--- a/src/tests/itests/tools/xi_itest_mock_broker_layer.c
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layer.c
@@ -70,7 +70,7 @@ xi_state_t xi_mock_broker_layer_push( void* context, void* data, xi_state_t in_o
 
     if ( in_out_state == XI_STATE_OK )
     {
-        /* duplicate the received data since it will forwarded into two directions */
+        /* duplicate the received data since it will be forwarded into two directions */
         xi_data_desc_t* orig = ( xi_data_desc_t* )data;
         xi_data_desc_t* copy =
             xi_make_desc_from_buffer_copy( orig->data_ptr, orig->length );
@@ -133,6 +133,8 @@ xi_state_t xi_mock_broker_layer_pull( void* context, void* data, xi_state_t in_o
         XI_CONNACK_REFUSED_NOT_AUTHORIZED        = 5
     };
 
+    printf("helloka\n");
+
     XI_MOCK_BROKER_CONDITIONAL__CHECK_EXPECTED( in_out_state, LAYER_LEVEL );
 
     xi_layer_t* layer                 = ( xi_layer_t* )XI_THIS_LAYER( context );
@@ -148,7 +150,7 @@ xi_state_t xi_mock_broker_layer_pull( void* context, void* data, xi_state_t in_o
         // const uint16_t msg_id = xi_mqtt_get_message_id( recvd_msg );
         const xi_mqtt_type_t recvd_msg_type = recvd_msg->common.common_u.common_bits.type;
 
-        xi_debug_format( "mock broker received message with type %d ", recvd_msg_type );
+        xi_debug_format( "mock broker received message with type %d\n", recvd_msg_type );
 
         XI_MOCK_BROKER_CONDITIONAL__CHECK_EXPECTED( recvd_msg_type, MQTT_LEVEL );
 
@@ -252,6 +254,18 @@ xi_state_t xi_mock_broker_layer_pull( void* context, void* data, xi_state_t in_o
                     }
                 }
             }
+            break;
+
+            case XI_MQTT_TYPE_PINGREQ:
+                {
+                    XI_ALLOC( xi_mqtt_message_t, mqtt_pingresp, in_out_state );
+                    memcpy( mqtt_pingresp, recvd_msg, sizeof( xi_mqtt_message_t ) );
+
+                    mqtt_pingresp->common.common_u.common_bits.type = XI_MQTT_TYPE_PINGRESP;
+
+                    in_out_state = XI_PROCESS_PUSH_ON_PREV_LAYER(
+                                          context, mqtt_pingresp, in_out_state );
+                }
             break;
 
             case XI_MQTT_TYPE_DISCONNECT:

--- a/src/tests/itests/tools/xi_itest_mock_broker_layer.h
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layer.h
@@ -8,6 +8,7 @@
 #define __XI_ITEST_MOCK_BROKER_LAYER_H__
 
 #include "xi_layer_interface.h"
+#include "xi_data_desc.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/tests/itests/tools/xi_itest_mock_broker_layer.h
+++ b/src/tests/itests/tools/xi_itest_mock_broker_layer.h
@@ -17,7 +17,8 @@ extern "C" {
 typedef enum xi_mock_broker_control_init_e {
     CONTROL_CONTINUE,
     CONTROL_ERROR,
-    CONTROL_SKIP_CHECK_EXPECTED
+    CONTROL_SKIP_CHECK_EXPECTED,
+    CONTROL_PULL_PINGREQ_SUPPRESS_RESPONSE
 } xi_mock_broker_control_t;
 
 typedef struct xi_mock_broker_data_s

--- a/src/tests/itests/tools/xi_mock_layer_tls_prev.c
+++ b/src/tests/itests/tools/xi_mock_layer_tls_prev.c
@@ -65,7 +65,6 @@ xi_mock_layer_tls_prev_push( void* context, void* data, xi_state_t in_out_state 
         case CONTROL_TLS_PREV_PUSH__WRITE_ERROR:
             {
                 xi_state_t state_to_return = mock_type( xi_state_t );
-                printf("state_to_return: %d\n", state_to_return );
 
                 return XI_PROCESS_PUSH_ON_NEXT_LAYER( context, NULL, state_to_return );
             }

--- a/src/tests/itests/tools/xi_mock_layer_tls_prev.c
+++ b/src/tests/itests/tools/xi_mock_layer_tls_prev.c
@@ -61,7 +61,15 @@ xi_mock_layer_tls_prev_push( void* context, void* data, xi_state_t in_out_state 
                                                XI_STATE_OK );
             }
         }
-        break;
+            break;
+        case CONTROL_TLS_PREV_PUSH__WRITE_ERROR:
+            {
+                xi_state_t state_to_return = mock_type( xi_state_t );
+                printf("state_to_return: %d\n", state_to_return );
+
+                return XI_PROCESS_PUSH_ON_NEXT_LAYER( context, NULL, state_to_return );
+            }
+            break;
         case CONTROL_TLS_PREV_CLOSE:
             return XI_PROCESS_CLOSE_ON_THIS_LAYER( context, NULL,
                                                    mock_type( xi_state_t ) );

--- a/src/tests/itests/tools/xi_mock_layer_tls_prev.h
+++ b/src/tests/itests/tools/xi_mock_layer_tls_prev.h
@@ -16,6 +16,7 @@ extern "C" {
 typedef enum xi_mock_layer_tls_prev_control_e {
     CONTROL_TLS_PREV_CONTINUE,
     CONTROL_TLS_PREV_PUSH__RETURN_MESSAGE,
+    CONTROL_TLS_PREV_PUSH__WRITE_ERROR,
     CONTROL_TLS_PREV_CLOSE
 } xi_mock_layer_tls_prev_control_t;
 

--- a/src/tests/itests/xi_itest_mqtt_keepalive.c
+++ b/src/tests/itests/xi_itest_mqtt_keepalive.c
@@ -154,8 +154,10 @@ void xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__client_disconnects_after_k
      * mock broker catches the message before IO layer */
     will_return( xi_mock_broker_layer_pull, CONTROL_PULL_PINGREQ_SUPPRESS_RESPONSE );
 
+#ifndef XI_MODULE_THREAD_ENABLED
     expect_value( _xi_itest_mqtt_keepalive__on_connection_state_changed, state, XI_STATE_OK );
     expect_value( _xi_itest_mqtt_keepalive__on_connection_state_changed, state, XI_STATE_TIMEOUT );
+#endif
 
     xi_itest_mqtt_keepalive__act( state, 0 );
 }
@@ -178,10 +180,12 @@ void xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__broker_disconnects_first( 
      * mock broker catches the message before IO layer */
     will_return( xi_mock_broker_layer_pull, CONTROL_PULL_PINGREQ_SUPPRESS_RESPONSE );
 
+#ifndef XI_MODULE_THREAD_ENABLED
     expect_value( _xi_itest_mqtt_keepalive__on_connection_state_changed, state, XI_STATE_OK );
     expect_value( _xi_itest_mqtt_keepalive__on_connection_state_changed, state,
                   XI_CONNECTION_RESET_BY_PEER_ERROR );
     expect_value( _xi_itest_mqtt_keepalive__on_connection_state_changed, state, XI_STATE_TIMEOUT );
+#endif
 
     xi_itest_mqtt_keepalive__act( state, 11 );
 }
@@ -206,10 +210,12 @@ void xi_itest_mqtt_keepalive__2nd_PINGREQ_failed_to_send__broker_disconnects_fir
      * mock broker catches the message before IO layer */
     will_return( xi_mock_broker_layer_pull, CONTROL_PULL_PINGREQ_SUPPRESS_RESPONSE );
 
+#ifndef XI_MODULE_THREAD_ENABLED
     expect_value( _xi_itest_mqtt_keepalive__on_connection_state_changed, state, XI_STATE_OK );
     expect_value( _xi_itest_mqtt_keepalive__on_connection_state_changed, state,
                   XI_CONNECTION_RESET_BY_PEER_ERROR );
     expect_value( _xi_itest_mqtt_keepalive__on_connection_state_changed, state, XI_STATE_TIMEOUT );
+#endif
 
     xi_itest_mqtt_keepalive__act( state, 18 );
 }

--- a/src/tests/itests/xi_itest_mqtt_keepalive.c
+++ b/src/tests/itests/xi_itest_mqtt_keepalive.c
@@ -1,0 +1,146 @@
+/* Copyright (c) 2003-2018, LogMeIn, Inc. All rights reserved.
+ *
+ * This is part of the Xively C Client library,
+ * it is licensed under the BSD 3-Clause license.
+ */
+
+#include <xively.h>
+#include <xi_macros.h>
+#include "xi_globals.h"
+#include "xi_itest_layerchain_ct_ml_mc.h"
+#include <xi_itest_mock_broker_layerchain.h>
+#include "xi_memory_checks.h"
+#include "xi_itest_helpers.h"
+#include "xi_handle.h"
+#include "xi_backoff_status_api.h"
+
+/* Depends on the xi_itest_tls_error.c */
+extern xi_context_t* xi_context;
+extern xi_context_handle_t xi_context_handle;
+extern xi_context_t* xi_context_mockbroker;
+/* end of dependency */
+
+typedef struct xi_itest_mqtt_keepalive__test_fixture_s
+{
+
+} xi_itest_mqtt_keepalive__test_fixture_t;
+
+
+int xi_itest_mqtt_keepalive_setup( void** fixture_void )
+{
+    XI_UNUSED( fixture_void );
+
+    xi_memory_limiter_tearup();
+
+    //*fixture_void = xi_itest_mqtt_keepalive__generate_fixture();
+
+    xi_globals.backoff_status.backoff_lut_i = 0;
+    xi_cancel_backoff_event();
+
+    xi_initialize( "xi_itest_mqtt_keepalive_account_id", "xi_itest_mqtt_keepalive_device_id" );
+
+    XI_CHECK_STATE( xi_create_context_with_custom_layers(
+        &xi_context, itest_ct_ml_mc_layer_chain, XI_LAYER_CHAIN_CT_ML_MC,
+        XI_LAYER_CHAIN_SCHEME_LENGTH( XI_LAYER_CHAIN_CT_ML_MC ) ) );
+
+    xi_find_handle_for_object( xi_globals.context_handles_vector, xi_context,
+                               &xi_context_handle );
+
+    XI_CHECK_STATE( xi_create_context_with_custom_layers(
+        &xi_context_mockbroker, itest_mock_broker_codec_layer_chain,
+        XI_LAYER_CHAIN_MOCK_BROKER_CODEC,
+        XI_LAYER_CHAIN_SCHEME_LENGTH( XI_LAYER_CHAIN_MOCK_BROKER_CODEC ) ) );
+
+    return 0;
+
+err_handling:
+    fail();
+
+    return 1;
+}
+
+int xi_itest_mqtt_keepalive_teardown( void** fixture_void )
+{
+    XI_UNUSED( fixture_void );
+
+    xi_delete_context( xi_context_handle );
+    xi_delete_context_with_custom_layers(
+        &xi_context_mockbroker, itest_mock_broker_codec_layer_chain,
+        XI_LAYER_CHAIN_SCHEME_LENGTH( XI_LAYER_CHAIN_MOCK_BROKER_CODEC ) );
+
+    xi_shutdown();
+
+    xi_itest_mqtt_keepalive__test_fixture_t* fixture =
+        ( xi_itest_mqtt_keepalive__test_fixture_t* )*fixture_void;
+
+    XI_SAFE_FREE( fixture );
+
+    return !xi_memory_limiter_teardown();
+}
+
+void _xi_itest_mqtt_keepalive__on_connection_state_changed( xi_context_handle_t in_context_handle,
+                                                            void* data,
+                                                            xi_state_t state )
+{
+    XI_UNUSED( in_context_handle );
+    XI_UNUSED( data );
+    XI_UNUSED( state );
+}
+
+/*********************************************************************************
+ * act ***************************************************************************
+ ********************************************************************************/
+static void xi_itest_mqtt_keepalive__act( void** fixture_void )
+{
+    {
+        /* turn off LAYER and MQTT LEVEL expectation checks to concentrate only on SFT
+         * protocol messages */
+        will_return_always( xi_mock_broker_layer__check_expected__LAYER_LEVEL,
+                            CONTROL_SKIP_CHECK_EXPECTED );
+
+        will_return_always( xi_mock_broker_layer__check_expected__MQTT_LEVEL,
+                            CONTROL_SKIP_CHECK_EXPECTED );
+
+        will_return_always( xi_mock_layer_tls_prev__check_expected__LAYER_LEVEL,
+                            CONTROL_SKIP_CHECK_EXPECTED );
+    }
+
+    const xi_itest_mqtt_keepalive__test_fixture_t* const fixture =
+        ( xi_itest_mqtt_keepalive__test_fixture_t* )*fixture_void;
+    XI_UNUSED( fixture );
+
+    XI_PROCESS_INIT_ON_THIS_LAYER(
+        &xi_context_mockbroker->layer_chain.top->layer_connection, NULL, XI_STATE_OK );
+
+    xi_evtd_step( xi_globals.evtd_instance, xi_bsp_time_getcurrenttime_seconds() );
+
+    const uint16_t connection_timeout = 20;
+    const uint16_t keepalive_timeout  = 6;
+    xi_connect( xi_context_handle, "itest_username", "itest_password", connection_timeout,
+                keepalive_timeout, XI_SESSION_CLEAN,
+                &_xi_itest_mqtt_keepalive__on_connection_state_changed );
+
+    const uint16_t loop_counter_max = 43;
+    uint16_t loop_counter = 0;
+    while ( xi_evtd_dispatcher_continue( xi_globals.evtd_instance ) == 1 &&
+            loop_counter < loop_counter_max )
+    {
+        printf( "loop_counter = %d\n", loop_counter );
+
+        xi_evtd_step( xi_globals.evtd_instance,
+                      xi_bsp_time_getcurrenttime_seconds() + loop_counter );
+        ++loop_counter;
+
+        if ( loop_counter_max - 5  == loop_counter )
+        {
+          xi_shutdown_connection( xi_context_handle );
+        }
+    }
+}
+
+
+void xi_itest_mqtt_keepalive_first( void** state )
+{
+  XI_UNUSED( state );
+  xi_itest_mqtt_keepalive__act( state );
+}

--- a/src/tests/itests/xi_itest_mqtt_keepalive.c
+++ b/src/tests/itests/xi_itest_mqtt_keepalive.c
@@ -20,19 +20,12 @@ extern xi_context_handle_t xi_context_handle;
 extern xi_context_t* xi_context_mockbroker;
 /* end of dependency */
 
-typedef struct xi_itest_mqtt_keepalive__test_fixture_s
-{
-
-} xi_itest_mqtt_keepalive__test_fixture_t;
-
 
 int xi_itest_mqtt_keepalive_setup( void** fixture_void )
 {
     XI_UNUSED( fixture_void );
 
     xi_memory_limiter_tearup();
-
-    //*fixture_void = xi_itest_mqtt_keepalive__generate_fixture();
 
     xi_globals.backoff_status.backoff_lut_i = 0;
     xi_cancel_backoff_event();
@@ -70,11 +63,6 @@ int xi_itest_mqtt_keepalive_teardown( void** fixture_void )
 
     xi_shutdown();
 
-    xi_itest_mqtt_keepalive__test_fixture_t* fixture =
-        ( xi_itest_mqtt_keepalive__test_fixture_t* )*fixture_void;
-
-    XI_SAFE_FREE( fixture );
-
     return !xi_memory_limiter_teardown();
 }
 
@@ -95,6 +83,7 @@ void _xi_itest_mqtt_keepalive__on_connection_state_changed( xi_context_handle_t 
 static void xi_itest_mqtt_keepalive__act( void** fixture_void,
                                           const uint16_t loop_id_reset_by_peer )
 {
+    XI_UNUSED( fixture_void );
     {
         /* turn off LAYER and MQTT LEVEL expectation checks to concentrate only on SFT
          * protocol messages */
@@ -107,10 +96,6 @@ static void xi_itest_mqtt_keepalive__act( void** fixture_void,
         will_return_always( xi_mock_layer_tls_prev__check_expected__LAYER_LEVEL,
                             CONTROL_SKIP_CHECK_EXPECTED );
     }
-
-    const xi_itest_mqtt_keepalive__test_fixture_t* const fixture =
-        ( xi_itest_mqtt_keepalive__test_fixture_t* )*fixture_void;
-    XI_UNUSED( fixture );
 
     XI_PROCESS_INIT_ON_THIS_LAYER(
         &xi_context_mockbroker->layer_chain.top->layer_connection, NULL, XI_STATE_OK );
@@ -143,7 +128,7 @@ static void xi_itest_mqtt_keepalive__act( void** fixture_void,
                 XI_CONNECTION_RESET_BY_PEER_ERROR );
         }
 
-        if ( loop_counter_disconnect  == loop_counter )
+        if ( loop_counter_disconnect == loop_counter )
         {
             xi_shutdown_connection( xi_context_handle );
         }

--- a/src/tests/itests/xi_itest_mqtt_keepalive.c
+++ b/src/tests/itests/xi_itest_mqtt_keepalive.c
@@ -74,7 +74,9 @@ void _xi_itest_mqtt_keepalive__on_connection_state_changed( xi_context_handle_t 
     XI_UNUSED( data );
     XI_UNUSED( state );
 
+#ifndef XI_MODULE_THREAD_ENABLED
     check_expected( state );
+#endif
 }
 
 /*********************************************************************************

--- a/src/tests/itests/xi_itest_mqtt_keepalive.c
+++ b/src/tests/itests/xi_itest_mqtt_keepalive.c
@@ -139,7 +139,11 @@ static void xi_itest_mqtt_keepalive__act( void** fixture_void,
 void xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__client_disconnects_after_keepalive_seconds( void** state )
 {
     /* let CONNECT and SUBSCRIBE writes succeed */
+#ifdef XI_CONTROL_TOPIC_ENABLED
     will_return_count( xi_mock_layer_tls_prev_push, CONTROL_TLS_PREV_CONTINUE, 2 );
+#else
+    will_return_count( xi_mock_layer_tls_prev_push, CONTROL_TLS_PREV_CONTINUE, 1 );
+#endif
 
     /* make first PINGREQ fail to write on the socket */
     will_return( xi_mock_layer_tls_prev_push, CONTROL_TLS_PREV_PUSH__WRITE_ERROR );
@@ -159,7 +163,11 @@ void xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__client_disconnects_after_k
 void xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__broker_disconnects_first( void** state )
 {
     /* let CONNECT and SUBSCRIBE writes succeed */
+#ifdef XI_CONTROL_TOPIC_ENABLED
     will_return_count( xi_mock_layer_tls_prev_push, CONTROL_TLS_PREV_CONTINUE, 2 );
+#else
+    will_return_count( xi_mock_layer_tls_prev_push, CONTROL_TLS_PREV_CONTINUE, 1 );
+#endif
 
     /* make first PINGREQ fail to write on the socket */
     will_return( xi_mock_layer_tls_prev_push, CONTROL_TLS_PREV_PUSH__WRITE_ERROR );
@@ -181,7 +189,11 @@ void xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__broker_disconnects_first( 
 void xi_itest_mqtt_keepalive__2nd_PINGREQ_failed_to_send__broker_disconnects_first( void** state )
 {
     /* let CONNECT and SUBSCRIBE writes succeed */
+#ifdef XI_CONTROL_TOPIC_ENABLED
     will_return_count( xi_mock_layer_tls_prev_push, CONTROL_TLS_PREV_CONTINUE, 3 );
+#else
+    will_return_count( xi_mock_layer_tls_prev_push, CONTROL_TLS_PREV_CONTINUE, 2 );
+#endif
 
     /* make first PINGREQ fail to write on the socket */
     will_return( xi_mock_layer_tls_prev_push, CONTROL_TLS_PREV_PUSH__WRITE_ERROR );

--- a/src/tests/itests/xi_itest_mqtt_keepalive.h
+++ b/src/tests/itests/xi_itest_mqtt_keepalive.h
@@ -16,6 +16,9 @@ xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__client_disconnects_after_keepal
 extern void
 xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__broker_disconnects_first(
     void** state );
+extern void
+xi_itest_mqtt_keepalive__2nd_PINGREQ_failed_to_send__broker_disconnects_first(
+    void** state );
 
 #ifdef XI_MOCK_TEST_PREPROCESSOR_RUN
 struct CMUnitTest xi_itests_mqtt_keepalive[] = {
@@ -25,6 +28,10 @@ struct CMUnitTest xi_itests_mqtt_keepalive[] = {
         xi_itest_mqtt_keepalive_teardown ),
     cmocka_unit_test_setup_teardown(
         xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__broker_disconnects_first,
+        xi_itest_mqtt_keepalive_setup,
+        xi_itest_mqtt_keepalive_teardown ),
+    cmocka_unit_test_setup_teardown(
+        xi_itest_mqtt_keepalive__2nd_PINGREQ_failed_to_send__broker_disconnects_first,
         xi_itest_mqtt_keepalive_setup,
         xi_itest_mqtt_keepalive_teardown ),
 };

--- a/src/tests/itests/xi_itest_mqtt_keepalive.h
+++ b/src/tests/itests/xi_itest_mqtt_keepalive.h
@@ -1,0 +1,26 @@
+/* Copyright (c) 2003-2018, LogMeIn, Inc. All rights reserved.
+ *
+ * This is part of the Xively C Client library,
+ * it is licensed under the BSD 3-Clause license.
+ */
+
+#ifndef __XI_ITEST_MQTT_KEEPALIVE_H__
+#define __XI_ITEST_MQTT_KEEPALIVE_H__
+
+extern int xi_itest_mqtt_keepalive_setup( void** state );
+extern int xi_itest_mqtt_keepalive_teardown( void** state );
+
+extern void
+xi_itest_mqtt_keepalive_first(
+    void** state );
+
+#ifdef XI_MOCK_TEST_PREPROCESSOR_RUN
+struct CMUnitTest xi_itests_mqtt_keepalive[] = {
+    cmocka_unit_test_setup_teardown(
+        xi_itest_mqtt_keepalive_first,
+        xi_itest_mqtt_keepalive_setup,
+        xi_itest_mqtt_keepalive_teardown ),
+};
+#endif
+
+#endif /* __XI_ITEST_MQTT_KEEPALIVE_H__ */

--- a/src/tests/itests/xi_itest_mqtt_keepalive.h
+++ b/src/tests/itests/xi_itest_mqtt_keepalive.h
@@ -11,13 +11,20 @@ extern int xi_itest_mqtt_keepalive_setup( void** state );
 extern int xi_itest_mqtt_keepalive_teardown( void** state );
 
 extern void
-xi_itest_mqtt_keepalive_first(
+xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__client_disconnects_after_keepalive_seconds(
+    void** state );
+extern void
+xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__broker_disconnects_first(
     void** state );
 
 #ifdef XI_MOCK_TEST_PREPROCESSOR_RUN
 struct CMUnitTest xi_itests_mqtt_keepalive[] = {
     cmocka_unit_test_setup_teardown(
-        xi_itest_mqtt_keepalive_first,
+        xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__client_disconnects_after_keepalive_seconds,
+        xi_itest_mqtt_keepalive_setup,
+        xi_itest_mqtt_keepalive_teardown ),
+    cmocka_unit_test_setup_teardown(
+        xi_itest_mqtt_keepalive__PINGREQ_failed_to_send__broker_disconnects_first,
         xi_itest_mqtt_keepalive_setup,
         xi_itest_mqtt_keepalive_teardown ),
 };

--- a/src/tests/itests/xi_itests.c
+++ b/src/tests/itests/xi_itests.c
@@ -12,6 +12,7 @@
 #include "xi_itest_tls_layer.h"
 #endif
 #include "xi_itest_mqttlogic_layer.h"
+#include "xi_itest_mqtt_keepalive.h"
 #ifdef XI_CONTROL_TOPIC_ENABLED
 #include "xi_itest_sft.h"
 #endif
@@ -20,6 +21,7 @@
 #include "xi_test_utils.h"
 #include "xi_lamp_communication.h"
 
+#if 0
 struct CMGroupTest groups[] = {cmocka_test_group( xi_itests_clean_session ),
                                cmocka_test_group( xi_itests_tls_error ),
 #ifndef XI_NO_TLS_LAYER
@@ -32,7 +34,11 @@ struct CMGroupTest groups[] = {cmocka_test_group( xi_itests_clean_session ),
                                cmocka_test_group( xi_itests_sft ),
 #endif
 #endif
+                               cmocka_test_group( xi_itests_mqtt_keepalive ),
                                cmocka_test_group_end};
+#else
+struct CMGroupTest groups[] = { cmocka_test_group( xi_itests_mqtt_keepalive ), cmocka_test_group_end };
+#endif
 
 int8_t xi_cm_strict_mock = 0;
 

--- a/src/tests/itests/xi_itests.c
+++ b/src/tests/itests/xi_itests.c
@@ -21,7 +21,6 @@
 #include "xi_test_utils.h"
 #include "xi_lamp_communication.h"
 
-#if 0
 struct CMGroupTest groups[] = {cmocka_test_group( xi_itests_clean_session ),
                                cmocka_test_group( xi_itests_tls_error ),
 #ifndef XI_NO_TLS_LAYER
@@ -36,9 +35,6 @@ struct CMGroupTest groups[] = {cmocka_test_group( xi_itests_clean_session ),
 #endif
                                cmocka_test_group( xi_itests_mqtt_keepalive ),
                                cmocka_test_group_end};
-#else
-struct CMGroupTest groups[] = { cmocka_test_group( xi_itests_mqtt_keepalive ), cmocka_test_group_end };
-#endif
 
 int8_t xi_cm_strict_mock = 0;
 


### PR DESCRIPTION
[ Description ]
Fix for handling socket disconnection after having write errors when attempting to send the keep alive ping request.
At disconnection the keepalive timeout guard task if forced to finish its job. Forced not from event scheduler but from the mqtt logic destructor. Although the task expected to be called only from event scheduler. This contract is guarded by the firing assert. Now timed event is cancelled before forcing its execution. 

[ JIRA ]
n/a

[ Reviewer ]
@atigyi

[ QA ]
Tested clients with backoff mode disabled. Clients used the same credentials and were disconnecting one another.  Set the MQTT keepalive time to the same time as backoff so that there were cases when the broker's duplicate credential disconnection event ran into the MQTT PingReq event (logged to ensure that this sometimes occurred).  Ran with the memory limiter enabled to ensure that memory wasn't leaking when these events occurred.  Ran a longevity test to see if repeated disconnections, and repeated MQTT PingReq teardowns, caused any instability.
Added 3 new keepalive integration test cases covering disconnecting socket after PINGREQ write error.

[ Release Notes ]
Bugfix - only in DEBUG mode - when socket disconnection happened before keepalive time interval passed after failing to write PINGREQ on the socket.
Fixes for when the MQTT Keep alive PingReq occurred at the same tick as socket was closed.