### PR TITLE
Feature/wolfssl implicitfallthrough

### DIFF
--- a/src/import/cn-cbor/src/cn-get.c
+++ b/src/import/cn-cbor/src/cn-get.c
@@ -20,6 +20,7 @@ cn_cbor* cn_cbor_mapget_int(const cn_cbor* cb, int key) {
       if (cp->v.uint == (unsigned long)key) {
         return cp->next;
       }
+      break;
     case CN_CBOR_INT:
       if (cp->v.sint == (long)key) {
         return cp->next;

--- a/src/import/tls/wolfssl.conf
+++ b/src/import/tls/wolfssl.conf
@@ -1,1 +1,1 @@
-CFLAGS=-Wimplicit-fallthrough=0 --enable-sni --enable-debug=no --enable-static=yes --enable-shared=no --disable-examples --disable-filesystem --enable-ocspstapling --disable-oldtls
+CFLAGS=-Wno-implicit-fallthrough --enable-sni --enable-debug=no --enable-static=yes --enable-shared=no --disable-examples --disable-filesystem --enable-ocspstapling --disable-oldtls

--- a/src/import/tls/wolfssl.conf
+++ b/src/import/tls/wolfssl.conf
@@ -1,1 +1,1 @@
---enable-sni --enable-debug=no --enable-static=yes --enable-shared=no --disable-examples --disable-filesystem --enable-ocspstapling --disable-oldtls
+CFLAGS=-Wimplicit-fallthrough=0 --enable-sni --enable-debug=no --enable-static=yes --enable-shared=no --disable-examples --disable-filesystem --enable-ocspstapling --disable-oldtls

--- a/src/libxively/control_topic/xi_control_topic_layer.c
+++ b/src/libxively/control_topic/xi_control_topic_layer.c
@@ -196,6 +196,7 @@ xi_state_t xi_on_control_message( xi_context_handle_t in_context_handle,
                 xi_sft_on_connected( layer_data->sft_context );
 #endif
             }
+            break;
         }
         case XI_SUB_CALL_MESSAGE:
         {
@@ -212,6 +213,7 @@ xi_state_t xi_on_control_message( xi_context_handle_t in_context_handle,
 
             xi_sft_on_message( layer_data->sft_context, control_message );
 #endif
+            break;
         }
 
         default:;


### PR DESCRIPTION
[ Description ]
Disables the implicit fall-through warnings when building wolfSSL. In the future we can re-enable them when we upgrade wolf versions (which has since added explicit fall-through instrumentation).  For now, though, the latest wolf Versions don't seem to play well with the ESP32 build, and there doesn't seem to be much need to upgrade it at this time.

[ Reviewer ]
@atigyi 

[ QA ]
Build and tested POSIX library and examples.
Built ESP32 build.

[ Release Notes ]
Build configuration change for building WolfSSL version on Ubuntu.