### PR TITLE
Bugfix/xi_desc_alloc_assert

### DIFF
--- a/src/libxively/xi_data_desc.c
+++ b/src/libxively/xi_data_desc.c
@@ -16,18 +16,16 @@ xi_data_desc_t* xi_make_empty_desc_alloc( size_t capacity )
     xi_state_t state = XI_STATE_OK;
 
     XI_ALLOC( xi_data_desc_t, data_desc, state );
-
-    XI_ALLOC_BUFFER_AT( unsigned char, data_desc->data_ptr, capacity, state );
-
+    data_desc->memory_type = XI_MEMORY_TYPE_MANAGED;
+    
+    XI_ALLOC_BUFFER_AT( unsigned char, data_desc->data_ptr, capacity, state );    
     data_desc->length      = 0;
     data_desc->capacity    = capacity;
-    data_desc->memory_type = XI_MEMORY_TYPE_MANAGED;
-
     return data_desc;
 
 err_handling:
     xi_free_desc( &data_desc );
-    return 0;
+    return NULL;
 }
 
 xi_data_desc_t* xi_make_desc_from_buffer_copy( unsigned const char* buffer, size_t len )
@@ -37,19 +35,17 @@ xi_data_desc_t* xi_make_desc_from_buffer_copy( unsigned const char* buffer, size
     xi_state_t state = XI_STATE_OK;
 
     XI_ALLOC( xi_data_desc_t, data_desc, state );
-    XI_ALLOC_BUFFER_AT( unsigned char, data_desc->data_ptr, len, state );
-
-    memcpy( data_desc->data_ptr, buffer, len );
-
-    data_desc->capacity    = len;
-    data_desc->length      = data_desc->capacity;
     data_desc->memory_type = XI_MEMORY_TYPE_MANAGED;
 
+    XI_ALLOC_BUFFER_AT( unsigned char, data_desc->data_ptr, len, state );
+    memcpy( data_desc->data_ptr, buffer, len );
+    data_desc->capacity    = len;
+    data_desc->length      = data_desc->capacity;
     return data_desc;
 
 err_handling:
     xi_free_desc( &data_desc );
-    return 0;
+    return NULL;
 }
 
 xi_data_desc_t* xi_make_desc_from_buffer_share( unsigned char* buffer, size_t len )
@@ -69,7 +65,7 @@ xi_data_desc_t* xi_make_desc_from_buffer_share( unsigned char* buffer, size_t le
 
 err_handling:
     xi_free_desc( &data_desc );
-    return 0;
+    return NULL;
 }
 
 xi_data_desc_t* xi_make_desc_from_string_copy( const char* str )
@@ -83,19 +79,17 @@ xi_data_desc_t* xi_make_desc_from_string_copy( const char* str )
     const size_t len = strlen( str );
 
     XI_ALLOC( xi_data_desc_t, data_desc, state );
+    data_desc->memory_type = XI_MEMORY_TYPE_MANAGED;
 
     XI_ALLOC_BUFFER_AT( unsigned char, data_desc->data_ptr, len, state );
     memcpy( data_desc->data_ptr, str, len );
-
     data_desc->capacity    = len;
     data_desc->length      = data_desc->capacity;
-    data_desc->memory_type = XI_MEMORY_TYPE_MANAGED;
-
     return data_desc;
 
 err_handling:
     xi_free_desc( &data_desc );
-    return 0;
+    return NULL;
 }
 
 xi_data_desc_t* xi_make_desc_from_string_share( const char* str )
@@ -120,7 +114,7 @@ xi_data_desc_t* xi_make_desc_from_string_share( const char* str )
 
 err_handling:
     xi_free_desc( &data_desc );
-    return 0;
+    return NULL;
 }
 
 xi_data_desc_t* xi_make_desc_from_float_copy( const float value )
@@ -148,7 +142,7 @@ xi_data_desc_t* xi_make_desc_from_float_copy( const float value )
 
 err_handling:
     xi_free_desc( &data_desc );
-    return 0;
+    return NULL;
 }
 
 void xi_free_desc( xi_data_desc_t** desc )

--- a/src/tests/utests/xi_utest_data_desc.c
+++ b/src/tests/utests/xi_utest_data_desc.c
@@ -244,6 +244,263 @@ XI_TT_TESTCASE_WITH_SETUP(
         tt_fail();
     } )
 
+#ifndef XI_MEMORY_LIMITER_ENABLED
+#define XI_MEMORY_LIMITER_ENABLED 1
+#endif 
+
+#ifdef XI_MEMORY_LIMITER_ENABLED
+XI_TT_TESTCASE(
+    utest__xi_make_desc_from_string_copy__valid_data__not_enough_memory_for_buffer,
+    {
+        /* size values */
+        size_t num_characters     = 700;
+        xi_state_t ret_state      = XI_STATE_OK;
+        char* origin_string       = NULL;
+        xi_data_desc_t* data_desc = NULL;
+        
+        const size_t allocation_space   = num_characters * sizeof( char ) +
+                                          sizeof( xi_data_desc_t ) +
+                                          sizeof( xi_data_desc_t ) +
+                                          2*sizeof( xi_memory_limiter_entry_t );
+        const size_t allocation_footprint = num_characters* sizeof( char ) +
+                                            sizeof( xi_memory_limiter_entry_t );
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                            allocation_space;
+
+        /* assumptions */
+        tt_assert( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT > allocation_footprint );
+
+        xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
+        tt_assert( memory_set_result == XI_STATE_OK );
+
+        XI_ALLOC_BUFFER_AT( char, origin_string, num_characters, ret_state );
+        size_t i = 0;
+        for ( ; i < num_characters - 1; ++i )
+        {
+            origin_string[i] = 'a';
+        }
+        origin_string[num_characters-1] = '\0';
+        tt_int_op( strlen( origin_string ), ==, num_characters - 1 );
+
+        /* test behavior */
+        data_desc = xi_make_desc_from_string_copy( origin_string );
+        tt_ptr_op( data_desc, ==, NULL );
+        
+        goto end;
+
+    err_handling:
+        tt_fail();
+    end:
+        if( data_desc != NULL )
+        {
+            xi_free_desc( &data_desc );
+        }
+        XI_SAFE_FREE( origin_string );
+        xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                     XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
+
+    } )
+
+    XI_TT_TESTCASE(
+    utest__xi_make_desc_from_string_copy__valid_data__not_enough_memory_for_descriptor,
+    {
+        /* size values */
+        size_t num_characters     = 700;
+        xi_state_t ret_state      = XI_STATE_OK;
+        char* origin_string       = NULL;
+        xi_data_desc_t* data_desc = NULL;
+        
+        const size_t allocation_space   = num_characters * sizeof( char ) +
+                                          sizeof( xi_data_desc_t ) +
+                                          sizeof( xi_memory_limiter_entry_t );
+        const size_t allocation_footprint = num_characters* sizeof( char ) +
+                                            sizeof( xi_memory_limiter_entry_t );
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                            allocation_space;
+
+        /* assumptions */
+        tt_assert( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT > allocation_footprint );
+
+        xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
+        tt_assert( memory_set_result == XI_STATE_OK );
+
+        XI_ALLOC_BUFFER_AT( char, origin_string, num_characters, ret_state );
+        size_t i = 0;
+        for ( ; i < num_characters - 1; ++i )
+        {
+            origin_string[i] = 'a';
+        }
+        origin_string[num_characters-1] = '\0';
+        tt_int_op( strlen( origin_string ), ==, num_characters - 1 );
+
+        /* test behavior */
+        data_desc = xi_make_desc_from_string_copy( origin_string );
+        tt_ptr_op( data_desc, ==, NULL );
+        goto end;
+
+    err_handling:
+        tt_fail();
+    end:
+        if( data_desc != NULL )
+        {
+            xi_free_desc( &data_desc );
+        }
+        XI_SAFE_FREE( origin_string );
+        xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                     XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
+
+    } )
+
+    XI_TT_TESTCASE(
+    utest__xi_make_desc_from_buffer_copy__valid_data__not_enough_memory_for_buffer,
+    {
+        /* size values */
+        size_t num_buffer_elements   = 700;
+        xi_state_t ret_state         = XI_STATE_OK;
+        unsigned char* origin_buffer = NULL;
+        xi_data_desc_t* data_desc    = NULL;
+        
+        const size_t buffer_size_in_bytes = num_buffer_elements * sizeof( unsigned char );
+        const size_t allocation_space   = buffer_size_in_bytes +
+                                          sizeof( xi_data_desc_t ) +
+                                          sizeof( xi_memory_limiter_entry_t );
+        const size_t allocation_footprint = buffer_size_in_bytes +
+                                            sizeof( xi_memory_limiter_entry_t );
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                         allocation_space;
+
+        /* assumptions */
+        tt_assert( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT > allocation_footprint );
+
+        xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
+        tt_assert( memory_set_result == XI_STATE_OK );
+
+        XI_ALLOC_BUFFER_AT( unsigned char, origin_buffer, num_buffer_elements, ret_state );
+
+        /* test behavior */
+        data_desc = xi_make_desc_from_buffer_copy( origin_buffer, num_buffer_elements );
+        tt_ptr_op( data_desc, ==, NULL );
+        
+        goto end;
+
+    err_handling:
+        tt_fail();
+    end:
+        if( data_desc != NULL )
+        {
+            xi_free_desc( &data_desc );
+        }
+        XI_SAFE_FREE( origin_buffer );
+        xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                     XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
+
+    } )
+
+
+    XI_TT_TESTCASE(
+    utest__xi_make_desc_from_buffer_copy__valid_data__not_enough_memory_for_descriptor,
+    {
+        /* size values */
+        size_t num_buffer_elements   = 700;
+        xi_state_t ret_state         = XI_STATE_OK;
+        unsigned char* origin_buffer = NULL;
+        xi_data_desc_t* data_desc    = NULL;
+        
+        const size_t buffer_size_in_bytes = num_buffer_elements * sizeof( unsigned char );
+        const size_t allocation_space   = buffer_size_in_bytes +
+                                          sizeof( xi_data_desc_t ) +
+                                          sizeof( xi_data_desc_t ) +
+                                          2*sizeof( xi_memory_limiter_entry_t );
+        const size_t allocation_footprint = buffer_size_in_bytes +
+                                            sizeof( xi_memory_limiter_entry_t );
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                         allocation_space;
+
+        /* assumptions */
+        tt_assert( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT > allocation_footprint );
+
+        xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
+        tt_assert( memory_set_result == XI_STATE_OK );
+
+        XI_ALLOC_BUFFER_AT( unsigned char, origin_buffer, num_buffer_elements, ret_state );
+
+        /* test behavior */
+        data_desc = xi_make_desc_from_buffer_copy( origin_buffer, num_buffer_elements );
+        tt_ptr_op( data_desc, ==, NULL );
+        
+        goto end;
+
+    err_handling:
+        tt_fail();
+    end:
+        if( data_desc != NULL )
+        {
+            xi_free_desc( &data_desc );
+        }
+        XI_SAFE_FREE( origin_buffer );
+        xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                     XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
+
+    } )
+
+    XI_TT_TESTCASE(
+    utest__xi_make_empty_desc_alloc__valid_data__not_enough_memory_for_descriptor,
+    {
+        /* size values */
+        size_t num_buffer_elements = 700;
+        xi_data_desc_t* data_desc  = NULL;
+        
+        const size_t allocation_space   = 1;
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                         allocation_space;
+
+        xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
+        tt_assert( memory_set_result == XI_STATE_OK );
+        
+        /* test behavior */ 
+        data_desc = xi_make_empty_desc_alloc( num_buffer_elements );
+        tt_ptr_op( data_desc, ==, NULL );
+
+    end:   
+        if( data_desc != NULL )
+        {
+            xi_free_desc( &data_desc );
+        }
+        xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                     XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
+
+    } )
+
+    XI_TT_TESTCASE(
+    utest__xi_make_empty_desc_alloc__valid_data__not_enough_memory_for_buffer,
+    {
+        /* size values */
+        size_t num_buffer_elements = 700;
+        xi_data_desc_t* data_desc  = NULL;
+        
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                         + sizeof( xi_data_desc_t) + sizeof( xi_memory_limiter_entry_t );
+
+
+        xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
+        tt_assert( memory_set_result == XI_STATE_OK );
+        
+        /* test behavior */
+        data_desc = xi_make_empty_desc_alloc( num_buffer_elements );
+        tt_ptr_op( data_desc, ==, NULL );
+
+    end:   
+        if( data_desc != NULL )
+        {
+            xi_free_desc( &data_desc );
+        }
+        xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                     XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
+
+    } )
+#endif // XI_MEMORY_LIMITER_ENABLED
+
+
 XI_TT_TESTCASE( utest__xi_make_desc_from_string_copy__null_data__null_returned, {
     char* origin_string       = NULL;
     xi_data_desc_t* data_desc = NULL;

--- a/src/tests/utests/xi_utest_data_desc.c
+++ b/src/tests/utests/xi_utest_data_desc.c
@@ -427,7 +427,7 @@ XI_TT_TESTCASE(
                                      XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
 
     } )
-#endif // XI_MEMORY_LIMITER_ENABLED
+#endif /* XI_MEMORY_LIMITER_ENABLED */
 
 
 XI_TT_TESTCASE( utest__xi_make_desc_from_string_copy__null_data__null_returned, {

--- a/src/tests/utests/xi_utest_data_desc.c
+++ b/src/tests/utests/xi_utest_data_desc.c
@@ -248,50 +248,28 @@ XI_TT_TESTCASE_WITH_SETUP(
 XI_TT_TESTCASE(
     utest__xi_make_desc_from_string_copy__valid_data__not_enough_memory_for_buffer,
     {
-        /* size values */
-        size_t num_characters     = 700;
-        xi_state_t ret_state      = XI_STATE_OK;
-        char* origin_string       = NULL;
+        const char source_string[] = "The quick brown fox jumps over the lazy dog";
         xi_data_desc_t* data_desc = NULL;
         
-        const size_t allocation_space   = num_characters * sizeof( char ) +
-                                          sizeof( xi_data_desc_t ) +
-                                          sizeof( xi_data_desc_t ) +
-                                          2*sizeof( xi_memory_limiter_entry_t );
-        const size_t allocation_footprint = num_characters* sizeof( char ) +
-                                            sizeof( xi_memory_limiter_entry_t );
-        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
-                                            allocation_space;
+        /* Limited memory space.  It does not include enough space
+           to allocate the buffer to copy the source_string into,
+           but enough to allocate the tracking data descriptor for the buffer. */
+        const size_t dest_footprint_allowance = sizeof( xi_data_desc_t ) +
+                                                sizeof( xi_memory_limiter_entry_t );
 
-        /* assumptions */
-        tt_assert( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT > allocation_footprint );
+        /* Set the maximum heap size.  Must include the System memory limit, too */
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                            dest_footprint_allowance;
 
         xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
         tt_assert( memory_set_result == XI_STATE_OK );
 
-        XI_ALLOC_BUFFER_AT( char, origin_string, num_characters, ret_state );
-        size_t i = 0;
-        for ( ; i < num_characters - 1; ++i )
-        {
-            origin_string[i] = 'a';
-        }
-        origin_string[num_characters-1] = '\0';
-        tt_int_op( strlen( origin_string ), ==, num_characters - 1 );
-
         /* test behavior */
-        data_desc = xi_make_desc_from_string_copy( origin_string );
-        tt_ptr_op( data_desc, ==, NULL );
-        
-        goto end;
-
-    err_handling:
-        tt_fail();
+        data_desc = xi_make_desc_from_string_copy( source_string );
+        tt_ptr_op( data_desc, ==, NULL );        
+    
     end:
-        if( data_desc != NULL )
-        {
-            xi_free_desc( &data_desc );
-        }
-        XI_SAFE_FREE( origin_string );
+        xi_free_desc( &data_desc );
         xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
                                      XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
 
@@ -300,48 +278,27 @@ XI_TT_TESTCASE(
     XI_TT_TESTCASE(
     utest__xi_make_desc_from_string_copy__valid_data__not_enough_memory_for_descriptor,
     {
-        /* size values */
-        size_t num_characters     = 700;
-        xi_state_t ret_state      = XI_STATE_OK;
-        char* origin_string       = NULL;
+        const char source_string[] = "The quick brown fox jumps over the lazy dog";
         xi_data_desc_t* data_desc = NULL;
         
-        const size_t allocation_space   = num_characters * sizeof( char ) +
-                                          sizeof( xi_data_desc_t ) +
-                                          sizeof( xi_memory_limiter_entry_t );
-        const size_t allocation_footprint = num_characters* sizeof( char ) +
-                                            sizeof( xi_memory_limiter_entry_t );
-        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
-                                            allocation_space;
+        /* Limited memory space.  It does not include enough space
+           to allocate the buffer to copy the source_string into,
+           nor the descriptor to track the allocation. */
+        const size_t dest_footprint_allowance = sizeof( xi_memory_limiter_entry_t );
 
-        /* assumptions */
-        tt_assert( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT > allocation_footprint );
+        /* Set the maximum heap size.  Must include the System memory limit, too */
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                            dest_footprint_allowance;
 
         xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
         tt_assert( memory_set_result == XI_STATE_OK );
 
-        XI_ALLOC_BUFFER_AT( char, origin_string, num_characters, ret_state );
-        size_t i = 0;
-        for ( ; i < num_characters - 1; ++i )
-        {
-            origin_string[i] = 'a';
-        }
-        origin_string[num_characters-1] = '\0';
-        tt_int_op( strlen( origin_string ), ==, num_characters - 1 );
-
         /* test behavior */
-        data_desc = xi_make_desc_from_string_copy( origin_string );
-        tt_ptr_op( data_desc, ==, NULL );
-        goto end;
-
-    err_handling:
-        tt_fail();
+        data_desc = xi_make_desc_from_string_copy( source_string );
+        tt_ptr_op( data_desc, ==, NULL );        
+    
     end:
-        if( data_desc != NULL )
-        {
-            xi_free_desc( &data_desc );
-        }
-        XI_SAFE_FREE( origin_string );
+        xi_free_desc( &data_desc );
         xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
                                      XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
 
@@ -350,90 +307,59 @@ XI_TT_TESTCASE(
     XI_TT_TESTCASE(
     utest__xi_make_desc_from_buffer_copy__valid_data__not_enough_memory_for_buffer,
     {
-        /* size values */
-        size_t num_buffer_elements   = 700;
-        xi_state_t ret_state         = XI_STATE_OK;
-        unsigned char* origin_buffer = NULL;
-        xi_data_desc_t* data_desc    = NULL;
+        const unsigned char source_buffer[] = "The quick brown fox jumps over the lazy dog";
+        const size_t buffer_size_in_bytes = sizeof( source_buffer );
+        xi_data_desc_t* data_desc = NULL;
         
-        const size_t buffer_size_in_bytes = num_buffer_elements * sizeof( unsigned char );
-        const size_t allocation_space   = buffer_size_in_bytes +
-                                          sizeof( xi_data_desc_t ) +
-                                          sizeof( xi_memory_limiter_entry_t );
-        const size_t allocation_footprint = buffer_size_in_bytes +
-                                            sizeof( xi_memory_limiter_entry_t );
-        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
-                                         allocation_space;
+        /* Limited memory space.  It does not include enough space
+           to allocate a buffer to copy the source_buffer into,
+           but enough to allocate the tracking data descriptor for that buffer. */
+        const size_t dest_footprint_allowance = sizeof( xi_data_desc_t ) +
+                                                sizeof( xi_memory_limiter_entry_t );
 
-        /* assumptions */
-        tt_assert( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT > allocation_footprint );
+        /* Set the maximum heap size.  Must include the System memory limit, too */
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                            dest_footprint_allowance;
 
         xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
         tt_assert( memory_set_result == XI_STATE_OK );
 
-        XI_ALLOC_BUFFER_AT( unsigned char, origin_buffer, num_buffer_elements, ret_state );
-
         /* test behavior */
-        data_desc = xi_make_desc_from_buffer_copy( origin_buffer, num_buffer_elements );
-        tt_ptr_op( data_desc, ==, NULL );
-        
-        goto end;
-
-    err_handling:
-        tt_fail();
+        data_desc = xi_make_desc_from_buffer_copy( source_buffer, buffer_size_in_bytes );
+        tt_ptr_op( data_desc, ==, NULL );        
+    
     end:
-        if( data_desc != NULL )
-        {
-            xi_free_desc( &data_desc );
-        }
-        XI_SAFE_FREE( origin_buffer );
+        xi_free_desc( &data_desc );
         xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
                                      XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
-
     } )
 
 
     XI_TT_TESTCASE(
     utest__xi_make_desc_from_buffer_copy__valid_data__not_enough_memory_for_descriptor,
     {
-        /* size values */
-        size_t num_buffer_elements   = 700;
-        xi_state_t ret_state         = XI_STATE_OK;
-        unsigned char* origin_buffer = NULL;
-        xi_data_desc_t* data_desc    = NULL;
+        const unsigned char source_buffer[] = "The quick brown fox jumps over the lazy dog";
+        const size_t buffer_size_in_bytes = sizeof( source_buffer );
+        xi_data_desc_t* data_desc = NULL;
         
-        const size_t buffer_size_in_bytes = num_buffer_elements * sizeof( unsigned char );
-        const size_t allocation_space   = buffer_size_in_bytes +
-                                          sizeof( xi_data_desc_t ) +
-                                          sizeof( xi_data_desc_t ) +
-                                          2*sizeof( xi_memory_limiter_entry_t );
-        const size_t allocation_footprint = buffer_size_in_bytes +
-                                            sizeof( xi_memory_limiter_entry_t );
-        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
-                                         allocation_space;
+        /* Limited memory space.  It does not include enough space
+           to allocate a buffer to copy the source_buffer into,
+           nor enough space to allocate the tracking data descriptorfor that buffer.*/
+        const size_t dest_footprint_allowance = sizeof( xi_memory_limiter_entry_t );
 
-        /* assumptions */
-        tt_assert( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT > allocation_footprint );
+        /* Set the maximum heap size.  Must include the System memory limit, too */
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                            dest_footprint_allowance;
 
         xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
         tt_assert( memory_set_result == XI_STATE_OK );
 
-        XI_ALLOC_BUFFER_AT( unsigned char, origin_buffer, num_buffer_elements, ret_state );
-
         /* test behavior */
-        data_desc = xi_make_desc_from_buffer_copy( origin_buffer, num_buffer_elements );
-        tt_ptr_op( data_desc, ==, NULL );
-        
-        goto end;
-
-    err_handling:
-        tt_fail();
+        data_desc = xi_make_desc_from_buffer_copy( source_buffer, buffer_size_in_bytes );
+        tt_ptr_op( data_desc, ==, NULL );        
+    
     end:
-        if( data_desc != NULL )
-        {
-            xi_free_desc( &data_desc );
-        }
-        XI_SAFE_FREE( origin_buffer );
+        xi_free_desc( &data_desc );
         xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
                                      XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
 
@@ -443,53 +369,60 @@ XI_TT_TESTCASE(
     utest__xi_make_empty_desc_alloc__valid_data__not_enough_memory_for_descriptor,
     {
         /* size values */
-        size_t num_buffer_elements = 700;
+        size_t buffer_size = 700;
         xi_data_desc_t* data_desc  = NULL;
         
-        const size_t allocation_space   = 1;
+        /* Limited memory space.  It does not include enough space
+           to allocate a buffer of the requested size (buffer_size)
+           nor enough space to allocate the tracking data descriptor for
+           that buffer.*/
+        const size_t dest_footprint_allowance = sizeof( xi_memory_limiter_entry_t );
+
+        /* Set the maximum heap size.  Must include the System memory limit, too */
         const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
-                                         allocation_space;
+                                         dest_footprint_allowance;
 
         xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
         tt_assert( memory_set_result == XI_STATE_OK );
         
         /* test behavior */ 
-        data_desc = xi_make_empty_desc_alloc( num_buffer_elements );
+        data_desc = xi_make_empty_desc_alloc( buffer_size );
         tt_ptr_op( data_desc, ==, NULL );
 
     end:   
-        if( data_desc != NULL )
-        {
-            xi_free_desc( &data_desc );
-        }
+        xi_free_desc( &data_desc );
         xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
                                      XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
-
     } )
+
 
     XI_TT_TESTCASE(
     utest__xi_make_empty_desc_alloc__valid_data__not_enough_memory_for_buffer,
     {
         /* size values */
-        size_t num_buffer_elements = 700;
+        size_t buffer_size = 700;
         xi_data_desc_t* data_desc  = NULL;
         
-        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
-                                         + sizeof( xi_data_desc_t) + sizeof( xi_memory_limiter_entry_t );
+        /* Limited memory space.  It does not include enough space
+           to allocate a buffer of the requested size (buffer_size)
+           bu enough space to allocate the tracking data descriptor for
+           that buffer.*/
+        const size_t dest_footprint_allowance   = sizeof( xi_data_desc_t ) +
+                                                  sizeof( xi_memory_limiter_entry_t );
 
+        /* Set the maximum heap size.  Must include the System memory limit, too */
+        const size_t memory_limit_size = XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
+                                         dest_footprint_allowance;
 
         xi_state_t memory_set_result = xi_set_maximum_heap_usage( memory_limit_size );
         tt_assert( memory_set_result == XI_STATE_OK );
         
-        /* test behavior */
-        data_desc = xi_make_empty_desc_alloc( num_buffer_elements );
+        /* test behavior */ 
+        data_desc = xi_make_empty_desc_alloc( buffer_size );
         tt_ptr_op( data_desc, ==, NULL );
 
     end:   
-        if( data_desc != NULL )
-        {
-            xi_free_desc( &data_desc );
-        }
+        xi_free_desc( &data_desc );
         xi_memory_limiter_set_limit( XI_MEMORY_LIMITER_SYSTEM_MEMORY_LIMIT +
                                      XI_MEMORY_LIMITER_APPLICATION_MEMORY_LIMIT );
 

--- a/src/tests/utests/xi_utest_data_desc.c
+++ b/src/tests/utests/xi_utest_data_desc.c
@@ -244,10 +244,6 @@ XI_TT_TESTCASE_WITH_SETUP(
         tt_fail();
     } )
 
-#ifndef XI_MEMORY_LIMITER_ENABLED
-#define XI_MEMORY_LIMITER_ENABLED 1
-#endif 
-
 #ifdef XI_MEMORY_LIMITER_ENABLED
 XI_TT_TESTCASE(
     utest__xi_make_desc_from_string_copy__valid_data__not_enough_memory_for_buffer,


### PR DESCRIPTION
[ Description ]
Fix in debug builds for a potential assertion scenario in our data model.  The scenario would occur when the library needed to allocate a dynamically sized buffer along with the xi_data_desc_t structure to track this allocation but didn't have enough free space to allocate both.  

This issue does not have a behavioral impact in release mode.

The problem would arise when the first allocation, the xi_data_desc_t, succeeds but there wasn't enough memory to subsequently create the dynamically-sized buffer.  Generally both allocations take place, and then the structure of the xi_data_desc_t is initialized afterwards with the buffer size data and a pointer to the buffer.  And additional data ownership field tracks who should deallocate the buffer later when the xi_data_desc_t structure is freed.  This last field is important to xi_free_desc() as it needs to know if it should free the buffer that the xi_data_desc_t points to, or if someone else owns that responsibility.

In the case when the xi_data_desc_t structure was properly allocated but the subsequent dynamically allocated buffer failed in allocation, the xi_data_desc_t initialization code was skipped.  When the de-allocation of the xi_data_desc_t structure occurs immediately following to cleanup the state after the error, the function xi_free_desc() would throw an assertion because the data ownership field wasn't set.

This assertion scenario has been fixed by setting up the required fields in the xi_data_desc_t before the dynamically allocated buffer malloc attempt occurs. This way if the malloc of the buffer fails, then xi_free_desc() has the information that it needs to operate on the xi_data_desc_t.

[ Reviewer ]
@atigyi 

[ QA ]
Numerous Unit Tests were created to test the various data buffer creation functions in xi_data_desc.c. These new unit tests exercise the scenarios when there's not enough memory to allocate the xi_data_desc_t, and another test to if it can allocate the xi_data_desc_t tracking structure, but not the related data buffer.

[ Release Notes ]
Fixes for assertions which would occur in xi_data_desc_t creation functions when the runtime doesn't have enough free memory to allocate the buffer.  This was only a debug assertion and this change has no impact on the behavior of the library in release mode.